### PR TITLE
Asynchronous callback functions for live data

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,7 @@ for hour in hour_data:
 
 ### Reading live measurements
 Note how you can register multiple callbacks for the same event. These will be run
-in order of which they were registered.
- > INFO: In the future, events should be declared async and all callbacks will be
- > ran asynchronously instead of sequentially.
+in asynchronously (at the same time)!
 ```python
 import tibber
 
@@ -108,12 +106,12 @@ account = tibber.Account(tibber.DEMO_TOKEN)
 home = account.homes[0]
 
 @home.event("live_measurement")
-def show_current_power(data):
+async def show_current_power(data):
   print(data.power)
 
 # Multiple callback functions for the same event!
 @home.event("live_measurement")
-def show_accumulated_cost(data):
+async def show_accumulated_cost(data):
   print(f"{data.accumulated_cost} {data.currency}")
   
 def when_to_stop(data):

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -118,7 +118,7 @@ a live measurement is available.
    home = account.homes[0]
 
    @home.event("live_measurement")  # register the following function to run when the live_measurement event is emitted
-   def process_data(data):  # Note the data parameter in the function. This is required and is of type LiveMeasurement.
+   async def process_data(data):  # Note the data parameter in the function. This is required and is of type LiveMeasurement.
       print(data.power)
 
    # Now start retrieving live measurements
@@ -141,7 +141,7 @@ will be stopped (and code execution will continue).
    home = account.homes[0]
 
    @home.event("live_measurement")  # register the following function to run when the live_measurement event is emitted
-   def process_data(data):  # Note the data parameter in the function. This is required and is of type LiveMeasurement.
+   async def process_data(data):  # Note the data parameter in the function. This is required and is of type LiveMeasurement.
       print(data.power)
 
    # Now start retrieving live measurements
@@ -155,7 +155,7 @@ will be stopped (and code execution will continue).
       home = account.homes[0]
    
       @home.event("live_measurement")  # register the following function to run when the live_measurement event is emitted
-      def process_data(data):  # Note the data parameter in the function. This is required and is of type LiveMeasurement.
+      async def process_data(data):  # Note the data parameter in the function. This is required and is of type LiveMeasurement.
          print(data.power)
 
       def my_exit_function(live_measurement_data):

--- a/tests/realtime/test_live_measurements.py
+++ b/tests/realtime/test_live_measurements.py
@@ -48,7 +48,7 @@ def test_retrieving_live_measurements(home):
         assert data.accumulated_cost > 0
         assert isinstance(data.accumulated_reward, (int, float))
         assert data.currency == "SEK"
-        assert data.min_power > 0
+        assert data.min_power >= 0
         assert data.max_power > 0
         assert data.average_power > 0
         assert isinstance(data.power_production, (int, float))

--- a/tests/realtime/test_live_measurements.py
+++ b/tests/realtime/test_live_measurements.py
@@ -19,7 +19,7 @@ def home():
 def test_adding_listener_with_unknown_event_raises_exception(home):
     with pytest.raises(ValueError):
         @home.event("invalid-event-name")
-        def callback(data):
+        async def callback(data):
             print(data)
 
 def test_starting_live_feed_with_no_listeners_shows_warning(home, caplog):
@@ -31,7 +31,7 @@ def test_retrieving_live_measurements(home):
     global callback_was_run
     callback_was_run = False
     @home.event("live_measurement")
-    def callback(data):
+    async def callback(data):
         global callback_was_run
         callback_was_run = True
         assert isinstance(data, LiveMeasurement)

--- a/tibber/types/home.py
+++ b/tibber/types/home.py
@@ -343,7 +343,7 @@ class TibberHome(NonDecoratedTibberHome):
             _logger.warning("The event that was broadcasted has no listeners / callbacks! Nothing was run.")
             return
 
-        await asyncio.gather(*self._callbacks[event])
+        await asyncio.gather(*[c(data) for c in self._callbacks[event]])
 
 
     async def close_websocket_connection(self) -> None:

--- a/tibber/types/home.py
+++ b/tibber/types/home.py
@@ -344,7 +344,10 @@ class TibberHome(NonDecoratedTibberHome):
         return False
 
     async def broadcast_event(self, event, data) -> None:
-        if not event in self._callbacks:
+        if event not in self._callbacks:
+            _logger.warning(f"The event \"{event}\" was attempted emitted, but does not exist. Nothing was run.")
+
+        if len(self._callbacks[event]) == 0:
             _logger.warning("The event that was broadcasted has no listeners / callbacks! Nothing was run.")
             return
 

--- a/tibber/types/home.py
+++ b/tibber/types/home.py
@@ -2,6 +2,7 @@
 import json
 import asyncio
 import logging
+import inspect
 from typing import Union
 from typing import Callable
 from typing import TYPE_CHECKING
@@ -199,6 +200,8 @@ class TibberHome(NonDecoratedTibberHome):
             :param callback: The function being decorated.
             :throws ValueError: if the given event is not a valid event.
             """
+            if not inspect.iscoroutinefunction(callback):
+                raise ValueError("Callback functions must be coroutines! Use the `async def` syntax, instead of just `def`.")
             if event_to_listen_for == "live_measurement":
                 # Create the live_measurement key if it does not exist already
                 if not ("live_measurement" in self._callbacks):

--- a/tibber/types/home.py
+++ b/tibber/types/home.py
@@ -186,7 +186,9 @@ class TibberHome(NonDecoratedTibberHome):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._websocket_client = None
-        self._callbacks = {}
+        self._callbacks = {
+            "live_measurement": []
+        }
 
     def event(self, event_to_listen_for) -> Callable:
         """Returns a decorator that registers the function being
@@ -200,17 +202,17 @@ class TibberHome(NonDecoratedTibberHome):
             :param callback: The function being decorated.
             :throws ValueError: if the given event is not a valid event.
             """
+            # Check if callback is a coroutine
             if not inspect.iscoroutinefunction(callback):
                 raise ValueError("Callback functions must be coroutines! Use the `async def` syntax, instead of just `def`.")
-            if event_to_listen_for == "live_measurement":
-                # Create the live_measurement key if it does not exist already
-                if not ("live_measurement" in self._callbacks):
-                    self._callbacks["live_measurement"] = []
-                # Append the callback function to the dict of callbacks
-                self._callbacks["live_measurement"].append(callback)
 
-            else: 
+            # If the key is not found - the event is not a valid event! 
+            # Valid events will be added directly to the line where _callbacks is initialized.
+            try:
+                self._callbacks[event_to_listen_for].append(callback)
+            except KeyError:
                 raise ValueError(f"Could not recognize the event you want to listen for: {event_to_listen_for}")
+
             return callback
         return decorator
 


### PR DESCRIPTION
Now the syntax will be like this:
```py
@home.event("live_measurement")
async def prcoess_data(data):
    print(data.power)
```
vs previously:

```py
@home.event("live_measurement")
def prcoess_data(data):
    print(data.power)
```

This allows for all callback functions to be run asynchronously (at the same time) instead of sequentially when multiple callback functions are registered.