### PR TITLE
Support for older Python versions

### DIFF
--- a/tibber/account.py
+++ b/tibber/account.py
@@ -39,13 +39,13 @@ class Account(QueryExecutor):
         """Fetches all available data from the API and caches it. This method is used in async
         contexts to avoid errors about an event loop already running."""
         data = await self.execute_async(
-            self.token, QueryBuilder.query_all_data, retries
+            self.token, QueryBuilder.query_all_data(), retries
         )
         self.update_cache(data)
 
     def fetch_all(self, retries=1):
         """Fetches all available data from the API and caches it."""
-        data = self.execute_query(self.token, QueryBuilder.query_all_data)
+        data = self.execute_query(self.token, QueryBuilder.query_all_data())
         self.update_cache(data)
 
     def update_cache(self, data):

--- a/tibber/networking/query_builder.py
+++ b/tibber/networking/query_builder.py
@@ -35,7 +35,7 @@ class QueryBuilder:
         according to the GraphQL structure of the Tibber API.
 
         Exmaple:
-            create_query("viewer", "homes", "currentSubscription", QueryBuilder.price_info)
+            create_query("viewer", "homes", "currentSubscription", QueryBuilder.price_info())
 
             This returns a string query that queries specifically for the
             price_info of the current subscription in all homes.
@@ -99,24 +99,21 @@ class QueryBuilder:
         return result_dict
 
     @classmethod
-    @property
     def query_all_data(cls) -> str:
-        return cls.create_query_from_dict(QueryBuilder.query)
+        return cls.create_query_from_dict(QueryBuilder.query())
 
     # -------------------------------------------------------------------
     # Query dicts for the Tibber API types. Remember that values ignored.
     # -------------------------------------------------------------------
 
     @classmethod
-    @property
     def query(cls) -> dict:
         """Return a dict with query values as keys for all information on the `Query` type. This type is the base type
         which all queries are nested in. Therefore, this query returns all information available from the api.
         """
-        return {"viewer": QueryBuilder.viewer}
+        return {"viewer": QueryBuilder.viewer()}
 
     @classmethod
-    @property
     def viewer(cls) -> dict:
         """Return a dict with query values as keys for all information on the `Viewer` type."""
         return {
@@ -124,12 +121,11 @@ class QueryBuilder:
             "userId": "",
             "name": "",
             "accountType": [],
-            "homes": QueryBuilder.home,
+            "homes": QueryBuilder.home(),
             "websocketSubscriptionUrl": "",
         }
 
     @classmethod
-    @property
     def home(cls) -> dict:
         """Return a dict with query values as keys for all information on the `Home` type."""
         return {
@@ -143,16 +139,15 @@ class QueryBuilder:
             "primaryHeatingSource": "",
             "hasVentilationSystem": False,
             "mainFuseSize": 0,
-            "address": QueryBuilder.address,
-            "owner": QueryBuilder.legal_entity,
-            "meteringPointData": QueryBuilder.metering_point_data,
-            "currentSubscription": QueryBuilder.subscription,
-            "subscriptions": QueryBuilder.subscription,
-            "features": QueryBuilder.features,
+            "address": QueryBuilder.address(),
+            "owner": QueryBuilder.legal_entity(),
+            "meteringPointData": QueryBuilder.metering_point_data(),
+            "currentSubscription": QueryBuilder.subscription(),
+            "subscriptions": QueryBuilder.subscription(),
+            "features": QueryBuilder.features(),
         }
 
     @classmethod
-    @property
     def address(cls) -> dict:
         """Return a dict with query values as keys for all information on the `Address` type."""
         return {
@@ -167,7 +162,6 @@ class QueryBuilder:
         }
 
     @classmethod
-    @property
     def legal_entity(cls) -> dict:
         """Return a dict with query values as keys for all information on the `LegalEntity` type."""
         return {
@@ -179,12 +173,11 @@ class QueryBuilder:
             "lastName": "",
             "organizationNo": "",
             "language": "",
-            "contactInfo": QueryBuilder.contact_info,
-            "address": QueryBuilder.address,
+            "contactInfo": QueryBuilder.contact_info(),
+            "address": QueryBuilder.address(),
         }
 
     @classmethod
-    @property
     def metering_point_data(cls) -> dict:
         """Return a dict with query values as keys for all information on the `MeteringPointData` type."""
         return {
@@ -199,54 +192,48 @@ class QueryBuilder:
         }
 
     @classmethod
-    @property
     def subscription(cls) -> dict:
         """Return a dict with query values as keys for all information on the `Subscription` type."""
         return {
             "id": "",
-            "subscriber": QueryBuilder.legal_entity,
+            "subscriber": QueryBuilder.legal_entity(),
             "validFrom": "",
             "validTo": "",
             "status": "",
-            "priceInfo": QueryBuilder.price_info,
-            "priceRating": QueryBuilder.price_rating,
+            "priceInfo": QueryBuilder.price_info(),
+            "priceRating": QueryBuilder.price_rating(),
         }
 
     @classmethod
-    @property
     def features(cls) -> dict:
         """Return a dict with query values as keys for all information on the `HomeFeatures` type."""
         return {"realTimeConsumptionEnabled": False}
 
     @classmethod
-    @property
     def contact_info(cls) -> dict:
         """Return a dict with query values as keys for all information on the `ContactInfo` type."""
         return {"email": "", "mobile": ""}
 
     @classmethod
-    @property
     def price_info(cls) -> dict:
         """Return a dict with query values as keys for all information on the `PriceInfo` type."""
         return {
-            "current": QueryBuilder.price,
-            "today": QueryBuilder.price,
-            "tomorrow": QueryBuilder.price,
+            "current": QueryBuilder.price(),
+            "today": QueryBuilder.price(),
+            "tomorrow": QueryBuilder.price(),
         }
 
     @classmethod
-    @property
     def price_rating(cls) -> dict:
         """Return a dict with query values as keys for all information on the `PriceRating` type."""
         return {
-            "thresholdPercentages": QueryBuilder.price_rating_threshold_percentages,
-            "hourly": QueryBuilder.price_rating_type,
-            "daily": QueryBuilder.price_rating_type,
-            "monthly": QueryBuilder.price_rating_type,
+            "thresholdPercentages": QueryBuilder.price_rating_threshold_percentages(),
+            "hourly": QueryBuilder.price_rating_type(),
+            "daily": QueryBuilder.price_rating_type(),
+            "monthly": QueryBuilder.price_rating_type(),
         }
 
     @classmethod
-    @property
     def price(cls) -> dict:
         """Return a dict with query values as keys for all information on the `Price` type."""
         return {
@@ -259,13 +246,11 @@ class QueryBuilder:
         }
 
     @classmethod
-    @property
     def price_rating_threshold_percentages(cls) -> dict:
         """Return a dict with query values as keys for all information on the `PriceRatingThresholdPercentages` type."""
         return {"high": 0.0, "low": 0.0}
 
     @classmethod
-    @property
     def price_rating_type(cls) -> dict:
         """Return a dict with query values as keys for all information on the `PriceRatingType` type."""
         return {
@@ -274,11 +259,10 @@ class QueryBuilder:
             "minTotal": 0.0,
             "maxTotal": 0.0,
             "currency": "",
-            "entries": QueryBuilder.price_rating_entry,
+            "entries": QueryBuilder.price_rating_entry(),
         }
 
     @classmethod
-    @property
     def price_rating_entry(cls) -> dict:
         """Return a dict with query values as keys for all information on the `PriceRatingEntry` type."""
         return {
@@ -297,7 +281,7 @@ class QueryBuilder:
 
     @classmethod
     def single_home(home_id: str) -> dict:
-        return {f"home({home_id})": QueryBuilder.home}
+        return {f"home({home_id})": QueryBuilder.home()}
 
     @classmethod
     def consumption_query(
@@ -320,9 +304,9 @@ class QueryBuilder:
         )
         return {
             f"consumption(resolution: {resolution}, {args}, filterEmptyNodes: {str(filter_empty_nodes).lower()})": {
-                "pageInfo": QueryBuilder.home_consumption_page_info,
-                "nodes": QueryBuilder.consumption,
-                "edges": QueryBuilder.home_consumption_edge,
+                "pageInfo": QueryBuilder.home_consumption_page_info(),
+                "nodes": QueryBuilder.consumption(),
+                "edges": QueryBuilder.home_consumption_edge(),
             }
         }
 
@@ -346,14 +330,13 @@ class QueryBuilder:
         )
         return {
             f"production(resolution: {resolution}, {args}, filterEmptyNodes: {str(filter_empty_nodes).lower()})": {
-                "pageInfo": QueryBuilder.home_production_page_info,
-                "nodes": QueryBuilder.production,
-                "edges": QueryBuilder.home_production_edge,
+                "pageInfo": QueryBuilder.home_production_page_info(),
+                "nodes": QueryBuilder.production(),
+                "edges": QueryBuilder.home_production_edge(),
             }
         }
 
     @classmethod
-    @property
     def home_consumption_page_info(cls):
         return {
             "endCursor": "",
@@ -368,7 +351,6 @@ class QueryBuilder:
         }
 
     @classmethod
-    @property
     def consumption(cls):
         return {
             "from": "",
@@ -382,12 +364,10 @@ class QueryBuilder:
         }
 
     @classmethod
-    @property
     def home_consumption_edge(cls):
-        return {"cursor": "", "node": QueryBuilder.consumption}
+        return {"cursor": "", "node": QueryBuilder.consumption()}
 
     @classmethod
-    @property
     def home_production_page_info(cls):
         return {
             "endCursor": "",
@@ -402,7 +382,6 @@ class QueryBuilder:
         }
 
     @classmethod
-    @property
     def production(cls):
         return {
             "from": "",
@@ -416,9 +395,8 @@ class QueryBuilder:
         }
 
     @classmethod
-    @property
     def home_production_edge(cls):
-        return {"cursor": "", "node": QueryBuilder.production}
+        return {"cursor": "", "node": QueryBuilder.production()}
 
     # Live data - This WILL be rewritten together with this whole class.
     # TODO: Rewrite the whole class from a dict-based approach to a string-based approach.

--- a/tibber/types/__init__.py
+++ b/tibber/types/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from tibber.types.address import Address
 from tibber.types.contact_info import ContactInfo
 from tibber.types.home import NonDecoratedTibberHome, TibberHome

--- a/tibber/types/__init__.py
+++ b/tibber/types/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from tibber.types.address import Address
 from tibber.types.contact_info import ContactInfo
 from tibber.types.home import NonDecoratedTibberHome, TibberHome

--- a/tibber/types/address.py
+++ b/tibber/types/address.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """A class representing the Address type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/address.py
+++ b/tibber/types/address.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 """A class representing the Address type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/consumption.py
+++ b/tibber/types/consumption.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """A class representing the Consumption type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/consumption.py
+++ b/tibber/types/consumption.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 """A class representing the Consumption type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/contact_info.py
+++ b/tibber/types/contact_info.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 """A class representing the ContactInfo type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/contact_info.py
+++ b/tibber/types/contact_info.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """A class representing the ContactInfo type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/home.py
+++ b/tibber/types/home.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """Classes representing the Home type from the GraphQL Tibber API."""
 import asyncio
 import inspect

--- a/tibber/types/home.py
+++ b/tibber/types/home.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 """Classes representing the Home type from the GraphQL Tibber API."""
 import asyncio
 import inspect

--- a/tibber/types/home_consumption_connection.py
+++ b/tibber/types/home_consumption_connection.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """A class representing the HomeConsumptionConnection type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/home_consumption_connection.py
+++ b/tibber/types/home_consumption_connection.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 """A class representing the HomeConsumptionConnection type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/home_consumption_edge.py
+++ b/tibber/types/home_consumption_edge.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 """A class representing the HomeConsumptionEdge type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/home_consumption_edge.py
+++ b/tibber/types/home_consumption_edge.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """A class representing the HomeConsumptionEdge type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/home_consumption_page_info.py
+++ b/tibber/types/home_consumption_page_info.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 """A class representing the HomeConsumptionPageInfo type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/home_consumption_page_info.py
+++ b/tibber/types/home_consumption_page_info.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """A class representing the HomeConsumptionPageInfo type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/home_features.py
+++ b/tibber/types/home_features.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """A class representing the HomeFeatures type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/home_features.py
+++ b/tibber/types/home_features.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 """A class representing the HomeFeatures type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/home_production_connection.py
+++ b/tibber/types/home_production_connection.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 """A class representing the HomeProductionConnection type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/home_production_connection.py
+++ b/tibber/types/home_production_connection.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """A class representing the HomeProductionConnection type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/home_production_edge.py
+++ b/tibber/types/home_production_edge.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 """A class representing the HomeProductionEdge type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/home_production_edge.py
+++ b/tibber/types/home_production_edge.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """A class representing the HomeProductionEdge type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/home_production_page_info.py
+++ b/tibber/types/home_production_page_info.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """A class representing the HomeProductionPageInfo type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/home_production_page_info.py
+++ b/tibber/types/home_production_page_info.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 """A class representing the HomeProductionPageInfo type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/legal_entity.py
+++ b/tibber/types/legal_entity.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 """A class representing the LegalEntity type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/legal_entity.py
+++ b/tibber/types/legal_entity.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """A class representing the LegalEntity type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/live_measurement.py
+++ b/tibber/types/live_measurement.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 """A class representing the LiveMeasurement type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/live_measurement.py
+++ b/tibber/types/live_measurement.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """A class representing the LiveMeasurement type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/metering_point_data.py
+++ b/tibber/types/metering_point_data.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """A class representing the MeteringPointData type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/metering_point_data.py
+++ b/tibber/types/metering_point_data.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 """A class representing the MeteringPointData type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/price.py
+++ b/tibber/types/price.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """A class representing the Price type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/price.py
+++ b/tibber/types/price.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 """A class representing the Price type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/price_info.py
+++ b/tibber/types/price_info.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """A class representing the PriceInfo type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/price_info.py
+++ b/tibber/types/price_info.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 """A class representing the PriceInfo type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/price_rating.py
+++ b/tibber/types/price_rating.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 """A class representing the PriceRating type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/price_rating.py
+++ b/tibber/types/price_rating.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """A class representing the PriceRating type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/price_rating_entry.py
+++ b/tibber/types/price_rating_entry.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 """A class representing the PriceRatingEntry type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/price_rating_entry.py
+++ b/tibber/types/price_rating_entry.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """A class representing the PriceRatingEntry type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/price_rating_threshold_percentages.py
+++ b/tibber/types/price_rating_threshold_percentages.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 """A class representing the PriceRatingThresholdPercentages type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/price_rating_threshold_percentages.py
+++ b/tibber/types/price_rating_threshold_percentages.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """A class representing the PriceRatingThresholdPercentages type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/price_rating_type.py
+++ b/tibber/types/price_rating_type.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 """A class representing the PriceRatingType type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING, List
 

--- a/tibber/types/price_rating_type.py
+++ b/tibber/types/price_rating_type.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """A class representing the PriceRatingType type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING, List
 

--- a/tibber/types/production.py
+++ b/tibber/types/production.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 """A class representing the Production type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/production.py
+++ b/tibber/types/production.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """A class representing the Production type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/push_notification_response.py
+++ b/tibber/types/push_notification_response.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 """A class representing the PushNotificationResponse type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/push_notification_response.py
+++ b/tibber/types/push_notification_response.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """A class representing the PushNotificationResponse type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/subscription.py
+++ b/tibber/types/subscription.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """A class representing the Subscription type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/subscription.py
+++ b/tibber/types/subscription.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 """A class representing the Subscription type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/viewer.py
+++ b/tibber/types/viewer.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """A class representing the Viewer type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 

--- a/tibber/types/viewer.py
+++ b/tibber/types/viewer.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 """A class representing the Viewer type from the GraphQL Tibber API."""
 from typing import TYPE_CHECKING
 


### PR DESCRIPTION
Removed `@property` decorator from all places where it was used together with the `@classmethod` decorator (This is apparently not supported in versions 3.8 and lower) and added the `from __future__ import annotations` import at the top of all type files to support type hinting in Python 3.8.

Python version 3.7 and 3.8 should now be supported! 🎉 