### PR TITLE
Enforce ruff formatting and import sorting in CI

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -14,10 +14,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/ruff-action@v3
+      - name: Lint and check import sorting
+        uses: astral-sh/ruff-action@v3
         with:
           args: check
           src: "./src"
+      - name: Check formatting
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: format --check
+          src: "."
   tests:
     name: Pytest
     runs-on: ubuntu-latest

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,12 +17,12 @@
 
 # -- Project information -----------------------------------------------------
 
-project = 'tibber.py'
-copyright = '2025, Eric Bieszczad-Stie'
-author = 'Eric Bieszczad-Stie'
+project = "tibber.py"
+copyright = "2025, Eric Bieszczad-Stie"
+author = "Eric Bieszczad-Stie"
 
 # The full version, including alpha/beta/rc tags
-release = '0.5.0'
+release = "0.5.0"
 
 
 # -- General configuration ---------------------------------------------------
@@ -31,14 +31,14 @@ release = '0.5.0'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx_rtd_theme',  # For the readthedocs theam
+    "sphinx_rtd_theme",  # For the readthedocs theam
     "sphinx.ext.autodoc",  # For auto generating docs from docstrings
     "sphinx_autodoc_typehints",  # For using type hints to autogenerate argument type documentation
-    "sphinx.ext.autosectionlabel"  # For referencing other headers within the same file
+    "sphinx.ext.autosectionlabel",  # For referencing other headers within the same file
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,4 +45,6 @@ dev = [
 ]
 
 [tool.ruff.lint]
+# I = isort: keep imports sorted; formatting itself is handled by `ruff format`.
+extend-select = ["I"]
 ignore = ["E402"]

--- a/src/tibber/networking/query_builder.py
+++ b/src/tibber/networking/query_builder.py
@@ -526,7 +526,7 @@ class QueryBuilder:
             sendPushNotification(input: {{
                 title: "{title}",
                 message: "{message}",
-                {'screenToOpen: ' + screen_to_open if screen_to_open else ""}
+                {"screenToOpen: " + screen_to_open if screen_to_open else ""}
             }}) {{
                 successful
                 pushedToNumberOfDevices

--- a/src/tibber/types/home.py
+++ b/src/tibber/types/home.py
@@ -337,8 +337,9 @@ class TibberHome(NonDecoratedTibberHome):
                 )
             ),
             jitter=backoff.full_jitter,
-            giveup=lambda e: isinstance(e, TransportQueryError)
-            or isinstance(e, ValueError),
+            giveup=lambda e: (
+                isinstance(e, TransportQueryError) or isinstance(e, ValueError)
+            ),
         )
 
         retry_subscribe = backoff.on_exception(
@@ -352,8 +353,9 @@ class TibberHome(NonDecoratedTibberHome):
                 )
             ),
             jitter=backoff.full_jitter,
-            giveup=lambda e: isinstance(e, TransportQueryError)
-            or isinstance(e, ValueError),
+            giveup=lambda e: (
+                isinstance(e, TransportQueryError) or isinstance(e, ValueError)
+            ),
         )
 
         _logger.debug("connecting to websocket")

--- a/tests/cached/test_account.py
+++ b/tests/cached/test_account.py
@@ -1,51 +1,61 @@
 """Tests for reading tibber.Account properties from cached values after the Tibber account is initialized."""
+
 import pytest
 
 import tibber
-from tibber.types import NonDecoratedTibberHome
-from tibber.types import Viewer
-from tibber.exceptions import UnauthenticatedException
+from tibber.types import NonDecoratedTibberHome, Viewer
 
 
 @pytest.fixture
 def unfetched_account():
     return tibber.Account(tibber.DEMO_TOKEN, immediate_update=False)
 
+
 def test_getting_viewer(account):
     assert isinstance(account.viewer, Viewer)
 
+
 def test_getting_name(account):
     assert account.name == "Arya Stark"
-    
+
+
 def test_getting_login(account):
     assert account.login == "arya@winterfell.com"
-    
+
+
 def test_getting_user_id(account):
     assert account.user_id == "dcc2355e-6f55-45c2-beb9-274241fe450c"
 
+
 def test_getting_account_type(account):
     assert account.account_type == ["customer"]
-    
+
+
 def test_getting_homes(account):
     assert len(account.homes) == 1
-    
+
+
 def test_homes_are_correct_type(account):
     assert all(isinstance(home, NonDecoratedTibberHome) for home in account.homes)
+
 
 # Something wrong with pytest
 # def test_incorrect_token():
 #     with pytest.raises(UnauthenticatedException):
 #         account = tibber.Account("invalidtoken")
 
+
 def test_getting_non_fetched_property_returns_none_or_empty(unfetched_account):
     """Trying to get a value which has not yet been fetched should return None"""
     assert unfetched_account.name == None
     assert unfetched_account.viewer.homes == []
 
+
 def test_set_token(account):
     assert account.token == tibber.DEMO_TOKEN
     account.token = "test"
     assert account.token == "test"
+
 
 def test_setting_token_to_non_string_raises_error(account):
     with pytest.raises(TypeError):

--- a/tests/cached/test_home.py
+++ b/tests/cached/test_home.py
@@ -1,43 +1,53 @@
 """Tests for reading tibber.TibberHome properties from cached values after the Tibber account is initialized."""
-import pytest
 
-import tibber
-from tibber.types import LegalEntity
-from tibber.types import MeteringPointData
-from tibber.types import Subscription
-from tibber.types import HomeFeatures
-from tibber.types import Address
+from tibber.types import (
+    Address,
+    HomeFeatures,
+    LegalEntity,
+    MeteringPointData,
+    Subscription,
+)
 
 
 def test_getting_id(home):
     assert home.id == "96a14971-525a-4420-aae9-e5aedaa129ff"
-    
+
+
 def test_getting_time_zome(home):
     assert home.time_zone == "Europe/Stockholm"
-    
+
+
 def test_getting_app_nickname(home):
     assert home.app_nickname == "Vitahuset"
-    
+
+
 def test_getting_size(home):
     assert home.size == 200
-    
+
+
 def test_getting_type(home):
     assert home.type == "HOUSE"
-    
+
+
 def test_getting_number_of_residents(home):
     assert home.number_of_residents == 5
-    
+
+
 def test_getting_primary_heating_source(home):
     assert home.primary_heating_source == "GROUND"
-    
+
+
 def test_getting_has_ventilation_system(home):
     assert home.has_ventilation_system == False
-    
+
+
 def test_getting_main_fuse_size(home):
     assert home.main_fuse_size == 25
 
+
 def test_getting_owner(home):
     assert isinstance(home.owner, LegalEntity)
+
 
 def test_getting_metering_point_data(home):
     assert isinstance(home.metering_point_data, MeteringPointData)
@@ -51,18 +61,23 @@ def test_getting_metering_point_data(home):
     assert data.production_ean == "735999102111362582"
     assert data.energy_tax_type == "normal"
 
+
 def test_getting_current_subscription(home):
     assert isinstance(home.current_subscription, Subscription)
+
 
 def test_getting_subscriptions(home):
     assert len(home.subscriptions) == 1
     assert isinstance(home.subscriptions[0], Subscription)
 
+
 def test_getting_features(home):
     assert isinstance(home.features, HomeFeatures)
-    
+
+
 def test_getting_address(home):
     assert isinstance(home.address, Address)
-    
+
+
 def test_getting_address1(home):
     assert home.address1 == "Winterfell Castle 1"

--- a/tests/cached/test_home_features.py
+++ b/tests/cached/test_home_features.py
@@ -1,5 +1,5 @@
 """Tests to verify home features data"""
-import pytest
+
 
 def test_real_time_consumption(home):
     assert home.features.real_time_consumption_enabled

--- a/tests/cached/test_legal_entity.py
+++ b/tests/cached/test_legal_entity.py
@@ -1,27 +1,34 @@
 """Tests for reading tibber.types.LegalEntity properties from cached values after the Tibber account is initialized."""
+
 import pytest
 
-import tibber
 from tibber.types import LegalEntity
+
 
 @pytest.fixture
 def legal_entity(home):
     return home.owner
 
+
 def test_correct_type(legal_entity):
     assert isinstance(legal_entity, LegalEntity)
+
 
 def test_getting_id(legal_entity):
     assert legal_entity.id == "dcc2355e-6f55-45c2-beb9-274241fe450c"
 
+
 def test_getting_first_name(legal_entity):
     assert legal_entity.first_name == "Arya"
+
 
 def test_getting_name(legal_entity):
     assert legal_entity.name == "Arya Stark"
 
+
 def test_getting_last_name(legal_entity):
     assert legal_entity.last_name == "Stark"
+
 
 def test_getting_contact_info(legal_entity):
     assert legal_entity.contact_info.email == "arya@winterfell.com"

--- a/tests/cached/test_subscription.py
+++ b/tests/cached/test_subscription.py
@@ -1,11 +1,8 @@
 """Tests for reading tibber.types.Subscription properties from cached values after the Tibber account is initialized."""
+
 import pytest
 
-import tibber
-from tibber.types import Subscription
-from tibber.types import LegalEntity
-from tibber.types import PriceInfo
-from tibber.types import PriceRating
+from tibber.types import LegalEntity, PriceInfo, PriceRating, Subscription
 
 
 @pytest.fixture
@@ -16,20 +13,26 @@ def subscription(home):
 def test_correct_type(subscription):
     assert isinstance(subscription, Subscription)
 
+
 def test_getting_id(subscription):
     assert subscription.id == "a386fd22-579e-4364-8b17-c63bef0d6bee"
+
 
 def test_getting_subscriber(subscription):
     assert isinstance(subscription.subscriber, LegalEntity)
 
+
 def test_getting_valid_from(subscription):
     assert subscription.valid_from == "2018-11-01T23:00:00+00:00"
+
 
 def test_getting_status(subscription):
     assert subscription.status == "running"
 
+
 def test_getting_price_info(subscription):
     assert isinstance(subscription.price_info, PriceInfo)
+
 
 def test_getting_price_rating(subscription):
     assert isinstance(subscription.price_rating, PriceRating)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,9 @@
+import json
+
 import pytest
 
 import tibber
-import json
+
 
 @pytest.fixture(scope="session")
 def account():
@@ -18,9 +20,12 @@ def account():
 
     return account
 
+
 @pytest.fixture(scope="session")
 def home(account):
     try:
         return account.homes[0]
     except IndexError:
-        raise ValueError("The instanciated demo account does not have any homes. Cannot perform home tests.")
+        raise ValueError(
+            "The instanciated demo account does not have any homes. Cannot perform home tests."
+        )

--- a/tests/fetched/test_consumption.py
+++ b/tests/fetched/test_consumption.py
@@ -1,14 +1,10 @@
 """Tests for fetching consumption data from the API."""
-from datetime import datetime
-from datetime import timedelta
-
-import pytest
-
-import tibber
 
 
 def test_consumption_page_info(home):
-    home_consumption_connection = home.fetch_consumption("HOURLY", first=5, after="MjAyMy0wMi0wNlQwMTowMDowMC4wMDArMDE6MDA=")
+    home_consumption_connection = home.fetch_consumption(
+        "HOURLY", first=5, after="MjAyMy0wMi0wNlQwMTowMDowMC4wMDArMDE6MDA="
+    )
     page_info = home_consumption_connection.page_info
 
     assert page_info.end_cursor == home_consumption_connection.edges[-1].cursor
@@ -22,8 +18,11 @@ def test_consumption_page_info(home):
     assert page_info.total_consumption == 16.633
     assert page_info.filtered == 0
 
+
 def test_consumption_nodes(home):
-    home_consumption_connection = home.fetch_consumption("HOURLY", first=3, after="MjAyMy0wMi0wNlQwMTowMDowMC4wMDArMDE6MDA=")
+    home_consumption_connection = home.fetch_consumption(
+        "HOURLY", first=3, after="MjAyMy0wMi0wNlQwMTowMDowMC4wMDArMDE6MDA="
+    )
     history = home_consumption_connection.nodes
 
     assert history[0].from_time == "2023-02-06T01:00:00.000+01:00"
@@ -34,4 +33,3 @@ def test_consumption_nodes(home):
     assert [node.unit_price_vat for node in history] == [0.2658075, 0.2491175, 0.280245]
     assert [node.consumption for node in history] == [2.893, 3.546, 3.969]
     assert all(node.consumption_unit == "kWh" for node in history)
-

--- a/tests/fetched/test_production.py
+++ b/tests/fetched/test_production.py
@@ -1,10 +1,4 @@
 """Tests for fetching production data from the API."""
-from datetime import datetime
-from datetime import timedelta
-
-import pytest
-
-import tibber
 
 
 # DISABLED in version 0.1.1 because the demo account has no power production...
@@ -12,12 +6,12 @@ import tibber
 # def test_production_page_info(home):
 #     home_production_connection = home.fetch_production("HOURLY", first=10, after="MjAyMi0wNi0xNFQxMzowMDowMC4wMDArMDI6MDA=")
 #     page_info = home_production_connection.page_info
-    
+
 #     assert page_info.end_cursor == home_production_connection.edges[-1].cursor
 #     assert page_info.has_next_page
 #     assert page_info.has_previous_page
 #     assert page_info.start_cursor == home_production_connection.edges[0].cursor
-    
+
 #     assert page_info.count == 10
 #     assert page_info.currency == "NOK"
 #     assert page_info.total_profit == 0.73834817

--- a/tests/fetched/test_range.py
+++ b/tests/fetched/test_range.py
@@ -1,19 +1,18 @@
 """Tests fetching historical price data."""
+
 import base64
-from datetime import datetime
-from datetime import timezone
-from datetime import timedelta
-
-import pytest
-
-import tibber
+from datetime import datetime, timedelta, timezone
 
 
 def test_fetching_hourly_prices(home):
     date = datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone(timedelta(hours=1)))
-    encoded = base64.b64encode(date.astimezone().isoformat().encode("utf-8")).decode("utf-8")
+    encoded = base64.b64encode(date.astimezone().isoformat().encode("utf-8")).decode(
+        "utf-8"
+    )
 
-    data = home.current_subscription.price_info.fetch_range("HOURLY", first="3", after=encoded)
+    data = home.current_subscription.price_info.fetch_range(
+        "HOURLY", first="3", after=encoded
+    )
 
     assert data.page_info.count == 3
     assert len(data.nodes) == 3

--- a/tests/realtime/test_live_measurements.py
+++ b/tests/realtime/test_live_measurements.py
@@ -1,7 +1,8 @@
 """Tests for reading live data from a tibber.TibberHome"""
+
+from datetime import datetime, timedelta
+
 import pytest
-from datetime import datetime
-from datetime import timedelta
 
 import tibber
 from tibber import __version__
@@ -10,9 +11,11 @@ from tibber.types.live_measurement import LiveMeasurement
 
 def test_adding_listener_with_unknown_event_raises_exception(home):
     with pytest.raises(ValueError):
+
         @home.event("invalid-event-name")
         async def callback(data):
             print(data)
+
 
 @pytest.mark.timeout(60)
 def test_starting_live_feed_with_no_listeners_shows_warning(caplog):
@@ -20,8 +23,14 @@ def test_starting_live_feed_with_no_listeners_shows_warning(caplog):
     home = account.homes[0]
 
     # Return immediately after the first callback
-    home.start_live_feed(f"tibber.py-tests/{__version__}", exit_condition = lambda data: True)
-    assert "The event that was broadcasted has no listeners / callbacks! Nothing was run." in caplog.text
+    home.start_live_feed(
+        f"tibber.py-tests/{__version__}", exit_condition=lambda data: True
+    )
+    assert (
+        "The event that was broadcasted has no listeners / callbacks! Nothing was run."
+        in caplog.text
+    )
+
 
 @pytest.mark.timeout(60)
 def test_retrieving_live_measurements():
@@ -42,5 +51,7 @@ def test_retrieving_live_measurements():
         assert timestamp > now - timedelta(seconds=30)
 
     # Return immediately after the first callback
-    home.start_live_feed(f"tibber.py-tests/{__version__}", exit_condition = lambda data: True)
+    home.start_live_feed(
+        f"tibber.py-tests/{__version__}", exit_condition=lambda data: True
+    )
     assert callback_was_run


### PR DESCRIPTION
One topic only: make `ruff format` and import sorting *enforced*, not just available.

- CI gains a `ruff format --check` gate — #67 formatted the code but nothing kept it formatted.
- ruff's isort rules (`I`) are enabled in `pyproject.toml`.
- The rest of the diff is exclusively the mechanical result: import-sort and formatting changes across `src/`, `tests/` and `docs/conf.py`. No annotations, no comparisons, no exception-handling changes, no behavior changes.
- Lint scope is unchanged (`src/` only, same rules as before plus `I`).

Re: the review on the previous revision — this branch was rebuilt from scratch to address it:
- CodeQL restore: moved to its own PR.
- The CI Python-matrix fix: moved to its own PR.
- CONTRIBUTING/README/badge links: moved to their own PR.
- All `Optional`/`.keys()`/`raise ... from` code changes: dropped from this PR entirely; they'll return in the type-checking PR where they're on topic. (FWIW `raise ... from e` is valid on Python 3.9 — it's Python 3 syntax — but it doesn't belong here anyway.)

Verified locally: `ruff check src`, `ruff format --check .` and the full test suite (46 passed) are green on Python 3.14 and 3.9.

https://claude.ai/code/session_01JzYRijrUxTCV4REzcTPPEi