### PR TITLE
Run the default test suite offline against recorded demo data

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,0 @@
-[report]
-exclude_lines = 
-    pragma: no cover
-    if TYPE_CHECKING:
-    logger

--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -1,0 +1,27 @@
+name: Live API tests
+
+# Runs the network-dependent part of the test suite (markers "live" and "realtime")
+# against the real Tibber demo API, to catch upstream API changes without making
+# regular CI flaky. Failures here indicate API drift, not broken PRs.
+on:
+  schedule:
+    - cron: "0 6 * * 1" # every Monday morning
+  workflow_dispatch:
+
+jobs:
+  live-tests:
+    runs-on: ubuntu-latest
+    env:
+      UV_CACHE_DIR: /tmp/.uv-cache
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Install Python
+        run: uv python install
+      - name: Install dependencies
+        run: uv sync
+      - name: Run live and realtime tests against the demo API
+        run: uv run -- pytest -m "live or realtime" tests
+      - name: Minimize uv cache
+        run: uv cache prune --ci

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,26 @@ module-name = "tibber"
 dev = [
     "pytest>=8.4.2",
     "pytest-cov>=7.0.0",
+    "pytest-timeout>=2.3.1",
     "ruff>=0.15.6",
 ]
 
 [tool.ruff.lint]
 ignore = ["E402"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+# The default suite is fully offline and deterministic. Network-dependent tests are
+# opt-in: run them with `pytest -m "live or realtime"` (see .github/workflows/live.yml).
+addopts = "--strict-markers -m 'not live and not realtime'"
+markers = [
+    "live: queries the real Tibber demo API over the network (deselected by default)",
+    "realtime: opens a websocket to the live measurement API (deselected by default)",
+]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+]
+fail_under = 75

--- a/tests/backup_demo_data.json
+++ b/tests/backup_demo_data.json
@@ -4,7 +4,6 @@
         "userId": "dcc2355e-6f55-45c2-beb9-274241fe450c",
         "name": "Arya Stark",
         "accountType": [
-            "tibber",
             "customer"
         ],
         "homes": [
@@ -12,8 +11,8 @@
                 "id": "96a14971-525a-4420-aae9-e5aedaa129ff",
                 "timeZone": "Europe/Stockholm",
                 "appNickname": "Vitahuset",
-                "appAvatar": "FLOORHOUSE3",
-                "size": 195,
+                "appAvatar": "CASTLE",
+                "size": 200,
                 "type": "HOUSE",
                 "numberOfResidents": 5,
                 "primaryHeatingSource": "GROUND",
@@ -76,401 +75,208 @@
                     "status": "running",
                     "priceInfo": {
                         "current": {
-                            "total": 2.2385,
-                            "energy": 1.6812,
-                            "tax": 0.5573,
-                            "startsAt": "2023-01-18T17:00:00.000+01:00",
+                            "total": 1.0832,
+                            "energy": 0.7738,
+                            "tax": 0.3094,
+                            "startsAt": "2026-06-10T00:00:00.000+02:00",
                             "currency": "SEK",
-                            "level": "VERY_EXPENSIVE"
+                            "level": "NORMAL"
                         },
                         "today": [
                             {
-                                "total": 0.6995,
-                                "energy": 0.45,
-                                "tax": 0.2495,
-                                "startsAt": "2023-01-18T00:00:00.000+01:00",
+                                "total": 1.0832,
+                                "energy": 0.7738,
+                                "tax": 0.3094,
+                                "startsAt": "2026-06-10T00:00:00.000+02:00",
                                 "currency": "SEK",
-                                "level": "CHEAP"
+                                "level": "NORMAL"
                             },
                             {
-                                "total": 0.6838,
-                                "energy": 0.4375,
-                                "tax": 0.2463,
-                                "startsAt": "2023-01-18T01:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "CHEAP"
-                            },
-                            {
-                                "total": 0.6831,
-                                "energy": 0.4369,
-                                "tax": 0.2462,
-                                "startsAt": "2023-01-18T02:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "CHEAP"
-                            },
-                            {
-                                "total": 0.6779,
-                                "energy": 0.4327,
-                                "tax": 0.2452,
-                                "startsAt": "2023-01-18T03:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "CHEAP"
-                            },
-                            {
-                                "total": 0.7397,
-                                "energy": 0.4822,
-                                "tax": 0.2575,
-                                "startsAt": "2023-01-18T04:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "CHEAP"
-                            },
-                            {
-                                "total": 0.872,
-                                "energy": 0.588,
+                                "total": 0.9559,
+                                "energy": 0.6719,
                                 "tax": 0.284,
-                                "startsAt": "2023-01-18T05:00:00.000+01:00",
+                                "startsAt": "2026-06-10T01:00:00.000+02:00",
+                                "currency": "SEK",
+                                "level": "CHEAP"
+                            },
+                            {
+                                "total": 1.1081,
+                                "energy": 0.7937,
+                                "tax": 0.3144,
+                                "startsAt": "2026-06-10T02:00:00.000+02:00",
                                 "currency": "SEK",
                                 "level": "NORMAL"
                             },
                             {
-                                "total": 1.0799,
-                                "energy": 0.7543,
-                                "tax": 0.3256,
-                                "startsAt": "2023-01-18T06:00:00.000+01:00",
+                                "total": 1.006,
+                                "energy": 0.712,
+                                "tax": 0.294,
+                                "startsAt": "2026-06-10T03:00:00.000+02:00",
                                 "currency": "SEK",
-                                "level": "EXPENSIVE"
+                                "level": "CHEAP"
                             },
                             {
-                                "total": 1.2658,
-                                "energy": 0.9031,
-                                "tax": 0.3627,
-                                "startsAt": "2023-01-18T07:00:00.000+01:00",
+                                "total": 0.9371,
+                                "energy": 0.6569,
+                                "tax": 0.2802,
+                                "startsAt": "2026-06-10T04:00:00.000+02:00",
                                 "currency": "SEK",
-                                "level": "EXPENSIVE"
+                                "level": "CHEAP"
                             },
                             {
-                                "total": 1.3024,
-                                "energy": 0.9323,
-                                "tax": 0.3701,
-                                "startsAt": "2023-01-18T08:00:00.000+01:00",
+                                "total": 0.89,
+                                "energy": 0.6192,
+                                "tax": 0.2708,
+                                "startsAt": "2026-06-10T05:00:00.000+02:00",
                                 "currency": "SEK",
-                                "level": "EXPENSIVE"
+                                "level": "CHEAP"
                             },
                             {
-                                "total": 1.3017,
-                                "energy": 0.9317,
-                                "tax": 0.37,
-                                "startsAt": "2023-01-18T09:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "EXPENSIVE"
-                            },
-                            {
-                                "total": 1.4063,
-                                "energy": 1.0154,
-                                "tax": 0.3909,
-                                "startsAt": "2023-01-18T10:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "VERY_EXPENSIVE"
-                            },
-                            {
-                                "total": 1.5337,
-                                "energy": 1.1174,
-                                "tax": 0.4163,
-                                "startsAt": "2023-01-18T11:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "VERY_EXPENSIVE"
-                            },
-                            {
-                                "total": 1.6887,
-                                "energy": 1.2414,
-                                "tax": 0.4473,
-                                "startsAt": "2023-01-18T12:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "VERY_EXPENSIVE"
-                            },
-                            {
-                                "total": 1.8244,
-                                "energy": 1.3499,
-                                "tax": 0.4745,
-                                "startsAt": "2023-01-18T13:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "VERY_EXPENSIVE"
-                            },
-                            {
-                                "total": 1.8825,
-                                "energy": 1.3964,
-                                "tax": 0.4861,
-                                "startsAt": "2023-01-18T14:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "VERY_EXPENSIVE"
-                            },
-                            {
-                                "total": 2.0116,
-                                "energy": 1.4996,
-                                "tax": 0.512,
-                                "startsAt": "2023-01-18T15:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "VERY_EXPENSIVE"
-                            },
-                            {
-                                "total": 2.1588,
-                                "energy": 1.6174,
-                                "tax": 0.5414,
-                                "startsAt": "2023-01-18T16:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "VERY_EXPENSIVE"
-                            },
-                            {
-                                "total": 2.2385,
-                                "energy": 1.6812,
-                                "tax": 0.5573,
-                                "startsAt": "2023-01-18T17:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "VERY_EXPENSIVE"
-                            },
-                            {
-                                "total": 2.0776,
-                                "energy": 1.5525,
-                                "tax": 0.5251,
-                                "startsAt": "2023-01-18T18:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "VERY_EXPENSIVE"
-                            },
-                            {
-                                "total": 1.9317,
-                                "energy": 1.4357,
-                                "tax": 0.496,
-                                "startsAt": "2023-01-18T19:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "VERY_EXPENSIVE"
-                            },
-                            {
-                                "total": 1.8446,
-                                "energy": 1.366,
-                                "tax": 0.4786,
-                                "startsAt": "2023-01-18T20:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "VERY_EXPENSIVE"
-                            },
-                            {
-                                "total": 1.8295,
-                                "energy": 1.354,
-                                "tax": 0.4755,
-                                "startsAt": "2023-01-18T21:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "VERY_EXPENSIVE"
-                            },
-                            {
-                                "total": 1.2986,
-                                "energy": 0.9293,
-                                "tax": 0.3693,
-                                "startsAt": "2023-01-18T22:00:00.000+01:00",
+                                "total": 1.1478,
+                                "energy": 0.8254,
+                                "tax": 0.3224,
+                                "startsAt": "2026-06-10T06:00:00.000+02:00",
                                 "currency": "SEK",
                                 "level": "NORMAL"
                             },
                             {
-                                "total": 1.2065,
-                                "energy": 0.8556,
-                                "tax": 0.3509,
-                                "startsAt": "2023-01-18T23:00:00.000+01:00",
+                                "total": 1.3209,
+                                "energy": 0.9639,
+                                "tax": 0.357,
+                                "startsAt": "2026-06-10T07:00:00.000+02:00",
+                                "currency": "SEK",
+                                "level": "NORMAL"
+                            },
+                            {
+                                "total": 1.1413,
+                                "energy": 0.8202,
+                                "tax": 0.3211,
+                                "startsAt": "2026-06-10T08:00:00.000+02:00",
+                                "currency": "SEK",
+                                "level": "NORMAL"
+                            },
+                            {
+                                "total": 0.779,
+                                "energy": 0.5304,
+                                "tax": 0.2486,
+                                "startsAt": "2026-06-10T09:00:00.000+02:00",
+                                "currency": "SEK",
+                                "level": "CHEAP"
+                            },
+                            {
+                                "total": 0.6469,
+                                "energy": 0.4247,
+                                "tax": 0.2222,
+                                "startsAt": "2026-06-10T10:00:00.000+02:00",
+                                "currency": "SEK",
+                                "level": "VERY_CHEAP"
+                            },
+                            {
+                                "total": 0.478,
+                                "energy": 0.2895,
+                                "tax": 0.1885,
+                                "startsAt": "2026-06-10T11:00:00.000+02:00",
+                                "currency": "SEK",
+                                "level": "VERY_CHEAP"
+                            },
+                            {
+                                "total": 0.372,
+                                "energy": 0.2048,
+                                "tax": 0.1672,
+                                "startsAt": "2026-06-10T12:00:00.000+02:00",
+                                "currency": "SEK",
+                                "level": "VERY_CHEAP"
+                            },
+                            {
+                                "total": 0.3001,
+                                "energy": 0.1473,
+                                "tax": 0.1528,
+                                "startsAt": "2026-06-10T13:00:00.000+02:00",
+                                "currency": "SEK",
+                                "level": "VERY_CHEAP"
+                            },
+                            {
+                                "total": 0.2516,
+                                "energy": 0.1085,
+                                "tax": 0.1431,
+                                "startsAt": "2026-06-10T14:00:00.000+02:00",
+                                "currency": "SEK",
+                                "level": "VERY_CHEAP"
+                            },
+                            {
+                                "total": 0.5078,
+                                "energy": 0.3134,
+                                "tax": 0.1944,
+                                "startsAt": "2026-06-10T15:00:00.000+02:00",
+                                "currency": "SEK",
+                                "level": "VERY_CHEAP"
+                            },
+                            {
+                                "total": 0.8294,
+                                "energy": 0.5707,
+                                "tax": 0.2587,
+                                "startsAt": "2026-06-10T16:00:00.000+02:00",
+                                "currency": "SEK",
+                                "level": "CHEAP"
+                            },
+                            {
+                                "total": 1.0328,
+                                "energy": 0.7334,
+                                "tax": 0.2994,
+                                "startsAt": "2026-06-10T17:00:00.000+02:00",
+                                "currency": "SEK",
+                                "level": "CHEAP"
+                            },
+                            {
+                                "total": 1.2246,
+                                "energy": 0.8869,
+                                "tax": 0.3377,
+                                "startsAt": "2026-06-10T18:00:00.000+02:00",
+                                "currency": "SEK",
+                                "level": "NORMAL"
+                            },
+                            {
+                                "total": 1.4324,
+                                "energy": 1.0531,
+                                "tax": 0.3793,
+                                "startsAt": "2026-06-10T19:00:00.000+02:00",
+                                "currency": "SEK",
+                                "level": "NORMAL"
+                            },
+                            {
+                                "total": 1.6137,
+                                "energy": 1.1981,
+                                "tax": 0.4156,
+                                "startsAt": "2026-06-10T20:00:00.000+02:00",
+                                "currency": "SEK",
+                                "level": "EXPENSIVE"
+                            },
+                            {
+                                "total": 1.5628,
+                                "energy": 1.1574,
+                                "tax": 0.4054,
+                                "startsAt": "2026-06-10T21:00:00.000+02:00",
+                                "currency": "SEK",
+                                "level": "EXPENSIVE"
+                            },
+                            {
+                                "total": 1.4174,
+                                "energy": 1.0412,
+                                "tax": 0.3762,
+                                "startsAt": "2026-06-10T22:00:00.000+02:00",
+                                "currency": "SEK",
+                                "level": "NORMAL"
+                            },
+                            {
+                                "total": 1.2653,
+                                "energy": 0.9194,
+                                "tax": 0.3459,
+                                "startsAt": "2026-06-10T23:00:00.000+02:00",
                                 "currency": "SEK",
                                 "level": "NORMAL"
                             }
                         ],
-                        "tomorrow": [
-                            {
-                                "total": 1.3036,
-                                "energy": 0.9333,
-                                "tax": 0.3703,
-                                "startsAt": "2023-01-19T00:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "NORMAL"
-                            },
-                            {
-                                "total": 1.2969,
-                                "energy": 0.9279,
-                                "tax": 0.369,
-                                "startsAt": "2023-01-19T01:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "NORMAL"
-                            },
-                            {
-                                "total": 1.2916,
-                                "energy": 0.9237,
-                                "tax": 0.3679,
-                                "startsAt": "2023-01-19T02:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "NORMAL"
-                            },
-                            {
-                                "total": 1.3226,
-                                "energy": 0.9485,
-                                "tax": 0.3741,
-                                "startsAt": "2023-01-19T03:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "NORMAL"
-                            },
-                            {
-                                "total": 1.4332,
-                                "energy": 1.037,
-                                "tax": 0.3962,
-                                "startsAt": "2023-01-19T04:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "NORMAL"
-                            },
-                            {
-                                "total": 1.6024,
-                                "energy": 1.1723,
-                                "tax": 0.4301,
-                                "startsAt": "2023-01-19T05:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "EXPENSIVE"
-                            },
-                            {
-                                "total": 1.7875,
-                                "energy": 1.3204,
-                                "tax": 0.4671,
-                                "startsAt": "2023-01-19T06:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "EXPENSIVE"
-                            },
-                            {
-                                "total": 2.2259,
-                                "energy": 1.6711,
-                                "tax": 0.5548,
-                                "startsAt": "2023-01-19T07:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "VERY_EXPENSIVE"
-                            },
-                            {
-                                "total": 2.3699,
-                                "energy": 1.7863,
-                                "tax": 0.5836,
-                                "startsAt": "2023-01-19T08:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "VERY_EXPENSIVE"
-                            },
-                            {
-                                "total": 2.3133,
-                                "energy": 1.741,
-                                "tax": 0.5723,
-                                "startsAt": "2023-01-19T09:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "VERY_EXPENSIVE"
-                            },
-                            {
-                                "total": 2.2984,
-                                "energy": 1.7291,
-                                "tax": 0.5693,
-                                "startsAt": "2023-01-19T10:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "VERY_EXPENSIVE"
-                            },
-                            {
-                                "total": 2.0725,
-                                "energy": 1.5484,
-                                "tax": 0.5241,
-                                "startsAt": "2023-01-19T11:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "VERY_EXPENSIVE"
-                            },
-                            {
-                                "total": 2.1819,
-                                "energy": 1.636,
-                                "tax": 0.5459,
-                                "startsAt": "2023-01-19T12:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "VERY_EXPENSIVE"
-                            },
-                            {
-                                "total": 2.2474,
-                                "energy": 1.6883,
-                                "tax": 0.5591,
-                                "startsAt": "2023-01-19T13:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "VERY_EXPENSIVE"
-                            },
-                            {
-                                "total": 2.3059,
-                                "energy": 1.7351,
-                                "tax": 0.5708,
-                                "startsAt": "2023-01-19T14:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "VERY_EXPENSIVE"
-                            },
-                            {
-                                "total": 2.5151,
-                                "energy": 1.9024,
-                                "tax": 0.6127,
-                                "startsAt": "2023-01-19T15:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "VERY_EXPENSIVE"
-                            },
-                            {
-                                "total": 2.6547,
-                                "energy": 2.0141,
-                                "tax": 0.6406,
-                                "startsAt": "2023-01-19T16:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "VERY_EXPENSIVE"
-                            },
-                            {
-                                "total": 2.5628,
-                                "energy": 1.9406,
-                                "tax": 0.6222,
-                                "startsAt": "2023-01-19T17:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "VERY_EXPENSIVE"
-                            },
-                            {
-                                "total": 2.3235,
-                                "energy": 1.7492,
-                                "tax": 0.5743,
-                                "startsAt": "2023-01-19T18:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "VERY_EXPENSIVE"
-                            },
-                            {
-                                "total": 2.2529,
-                                "energy": 1.6927,
-                                "tax": 0.5602,
-                                "startsAt": "2023-01-19T19:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "VERY_EXPENSIVE"
-                            },
-                            {
-                                "total": 2.1705,
-                                "energy": 1.6268,
-                                "tax": 0.5437,
-                                "startsAt": "2023-01-19T20:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "VERY_EXPENSIVE"
-                            },
-                            {
-                                "total": 2.1427,
-                                "energy": 1.6046,
-                                "tax": 0.5381,
-                                "startsAt": "2023-01-19T21:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "VERY_EXPENSIVE"
-                            },
-                            {
-                                "total": 1.7984,
-                                "energy": 1.3291,
-                                "tax": 0.4693,
-                                "startsAt": "2023-01-19T22:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "EXPENSIVE"
-                            },
-                            {
-                                "total": 1.6198,
-                                "energy": 1.1863,
-                                "tax": 0.4335,
-                                "startsAt": "2023-01-19T23:00:00.000+01:00",
-                                "currency": "SEK",
-                                "level": "NORMAL"
-                            }
-                        ]
+                        "tomorrow": []
                     },
                     "priceRating": {
                         "thresholdPercentages": {
@@ -478,2300 +284,1140 @@
                             "low": -10
                         },
                         "hourly": {
-                            "minEnergy": 0.0011,
-                            "maxEnergy": 2.0141,
-                            "minTotal": 0.1384,
-                            "maxTotal": 2.6547,
+                            "minEnergy": 0.1085,
+                            "maxEnergy": 2.0519,
+                            "minTotal": 0.2516,
+                            "maxTotal": 2.6808,
                             "currency": "SEK",
                             "entries": [
                                 {
-                                    "time": "2023-01-11T00:00:00.000+01:00",
-                                    "energy": 0.4702,
-                                    "total": 0.7248,
-                                    "tax": 0.2546,
-                                    "difference": -39.62886833254673,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-11T01:00:00.000+01:00",
-                                    "energy": 0.3102,
-                                    "total": 0.5248,
-                                    "tax": 0.2146,
-                                    "difference": -60.17200118408336,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-11T02:00:00.000+01:00",
-                                    "energy": 0.2816,
-                                    "total": 0.489,
-                                    "tax": 0.2074,
-                                    "difference": -63.84408618129553,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-11T03:00:00.000+01:00",
-                                    "energy": 0.2525,
-                                    "total": 0.4526,
-                                    "tax": 0.2001,
-                                    "difference": -67.58036846866875,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-11T04:00:00.000+01:00",
-                                    "energy": 0.2852,
-                                    "total": 0.4935,
-                                    "tax": 0.2083,
-                                    "difference": -63.38186569213596,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-11T05:00:00.000+01:00",
-                                    "energy": 0.2976,
-                                    "total": 0.509,
-                                    "tax": 0.2114,
-                                    "difference": -61.78977289614187,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-11T06:00:00.000+01:00",
-                                    "energy": 0.5431,
-                                    "total": 0.8158,
-                                    "tax": 0.2727,
-                                    "difference": -30.268903427065354,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-11T07:00:00.000+01:00",
-                                    "energy": 0.7999,
-                                    "total": 1.1368,
-                                    "tax": 0.3369,
-                                    "difference": 2.7028247996509407,
+                                    "time": "2026-06-08T00:00:00.000+02:00",
+                                    "energy": 0.9424,
+                                    "total": 1.294,
+                                    "tax": 0.3516,
+                                    "difference": -3.4152715719529994,
                                     "level": "NORMAL"
                                 },
                                 {
-                                    "time": "2023-01-11T08:00:00.000+01:00",
-                                    "energy": 0.8135,
-                                    "total": 1.1539,
-                                    "tax": 0.3404,
-                                    "difference": 4.448991092031534,
+                                    "time": "2026-06-08T01:00:00.000+02:00",
+                                    "energy": 0.9321,
+                                    "total": 1.2812,
+                                    "tax": 0.3491,
+                                    "difference": -4.470898378838484,
                                     "level": "NORMAL"
                                 },
                                 {
-                                    "time": "2023-01-11T09:00:00.000+01:00",
-                                    "energy": 0.7827,
-                                    "total": 1.1154,
-                                    "tax": 0.3327,
-                                    "difference": 0.49443801811075616,
+                                    "time": "2026-06-08T02:00:00.000+02:00",
+                                    "energy": 0.9208,
+                                    "total": 1.267,
+                                    "tax": 0.3462,
+                                    "difference": -5.629013225227425,
                                     "level": "NORMAL"
                                 },
                                 {
-                                    "time": "2023-01-11T10:00:00.000+01:00",
-                                    "energy": 0.7708,
-                                    "total": 1.1005,
-                                    "tax": 0.3297,
-                                    "difference": -1.0334574877222735,
+                                    "time": "2026-06-08T03:00:00.000+02:00",
+                                    "energy": 0.9086,
+                                    "total": 1.2517,
+                                    "tax": 0.3431,
+                                    "difference": -6.87936730716946,
                                     "level": "NORMAL"
                                 },
                                 {
-                                    "time": "2023-01-11T11:00:00.000+01:00",
-                                    "energy": 0.7752,
-                                    "total": 1.106,
-                                    "tax": 0.3308,
-                                    "difference": -0.46852133430502363,
+                                    "time": "2026-06-08T04:00:00.000+02:00",
+                                    "energy": 0.9369,
+                                    "total": 1.2871,
+                                    "tax": 0.3502,
+                                    "difference": -3.9789557892219563,
                                     "level": "NORMAL"
                                 },
                                 {
-                                    "time": "2023-01-11T12:00:00.000+01:00",
-                                    "energy": 0.7704,
-                                    "total": 1.1,
-                                    "tax": 0.3296,
-                                    "difference": -1.0848153198511312,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2023-01-11T13:00:00.000+01:00",
-                                    "energy": 0.7474,
-                                    "total": 1.0712,
-                                    "tax": 0.3238,
-                                    "difference": -4.037890667259518,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2023-01-11T14:00:00.000+01:00",
-                                    "energy": 0.7778,
-                                    "total": 1.1093,
-                                    "tax": 0.3315,
-                                    "difference": -0.1346954254675552,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2023-01-11T15:00:00.000+01:00",
-                                    "energy": 0.8493,
-                                    "total": 1.1986,
-                                    "tax": 0.3493,
-                                    "difference": 9.04551706756287,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2023-01-11T16:00:00.000+01:00",
-                                    "energy": 0.8597,
-                                    "total": 1.2116,
-                                    "tax": 0.3519,
-                                    "difference": 10.380820702912757,
+                                    "time": "2026-06-08T05:00:00.000+02:00",
+                                    "energy": 1.0905,
+                                    "total": 1.4791,
+                                    "tax": 0.3886,
+                                    "difference": 11.763207078507264,
                                     "level": "HIGH"
                                 },
                                 {
-                                    "time": "2023-01-11T17:00:00.000+01:00",
-                                    "energy": 0.8288,
-                                    "total": 1.173,
-                                    "tax": 0.3442,
-                                    "difference": 6.413428170959733,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2023-01-11T18:00:00.000+01:00",
-                                    "energy": 0.84,
-                                    "total": 1.187,
-                                    "tax": 0.347,
-                                    "difference": 7.851447470567294,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2023-01-11T19:00:00.000+01:00",
-                                    "energy": 0.7607,
-                                    "total": 1.0879,
-                                    "tax": 0.3272,
-                                    "difference": -2.330242748975536,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2023-01-11T20:00:00.000+01:00",
-                                    "energy": 0.729,
-                                    "total": 1.0483,
-                                    "tax": 0.3193,
-                                    "difference": -6.400350945186233,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2023-01-11T21:00:00.000+01:00",
-                                    "energy": 0.6714,
-                                    "total": 0.9763,
-                                    "tax": 0.3049,
-                                    "difference": -13.795878771739424,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-11T22:00:00.000+01:00",
-                                    "energy": 0.5584,
-                                    "total": 0.835,
-                                    "tax": 0.2766,
-                                    "difference": -28.304466348137154,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-11T23:00:00.000+01:00",
-                                    "energy": 0.4847,
-                                    "total": 0.7428,
-                                    "tax": 0.2581,
-                                    "difference": -37.76714691787622,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-12T00:00:00.000+01:00",
-                                    "energy": 0.2239,
-                                    "total": 0.4169,
-                                    "tax": 0.193,
-                                    "difference": -71.25245346588093,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-12T01:00:00.000+01:00",
-                                    "energy": 0.0625,
-                                    "total": 0.2152,
-                                    "tax": 0.1527,
-                                    "difference": -91.9753387298685,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-12T02:00:00.000+01:00",
-                                    "energy": 0.0528,
-                                    "total": 0.203,
-                                    "tax": 0.1502,
-                                    "difference": -93.22076615899292,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-12T03:00:00.000+01:00",
-                                    "energy": 0.0011,
-                                    "total": 0.1384,
-                                    "tax": 0.1373,
-                                    "difference": -99.85876596164569,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-12T04:00:00.000+01:00",
-                                    "energy": 0.0308,
-                                    "total": 0.1754,
-                                    "tax": 0.1446,
-                                    "difference": -96.0454469260792,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-12T05:00:00.000+01:00",
-                                    "energy": 0.2809,
-                                    "total": 0.4882,
-                                    "tax": 0.2073,
-                                    "difference": -63.93396238752101,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-12T06:00:00.000+01:00",
-                                    "energy": 0.4056,
-                                    "total": 0.644,
-                                    "tax": 0.2384,
-                                    "difference": -47.92315822135465,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-12T07:00:00.000+01:00",
-                                    "energy": 0.6756,
-                                    "total": 0.9816,
-                                    "tax": 0.306,
-                                    "difference": -13.256621534386582,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-12T08:00:00.000+01:00",
-                                    "energy": 0.7342,
-                                    "total": 1.0548,
-                                    "tax": 0.3206,
-                                    "difference": -5.732699127511296,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2023-01-12T09:00:00.000+01:00",
-                                    "energy": 0.7325,
-                                    "total": 1.0527,
-                                    "tax": 0.3202,
-                                    "difference": -5.950969914058874,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2023-01-12T10:00:00.000+01:00",
-                                    "energy": 0.7468,
-                                    "total": 1.0706,
-                                    "tax": 0.3238,
-                                    "difference": -4.114927415452769,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2023-01-12T11:00:00.000+01:00",
-                                    "energy": 0.7516,
-                                    "total": 1.0765,
-                                    "tax": 0.3249,
-                                    "difference": -3.4986334299066755,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2023-01-12T12:00:00.000+01:00",
-                                    "energy": 0.7502,
-                                    "total": 1.0748,
-                                    "tax": 0.3246,
-                                    "difference": -3.6783858423576277,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2023-01-12T13:00:00.000+01:00",
-                                    "energy": 0.7981,
-                                    "total": 1.1346,
-                                    "tax": 0.3365,
-                                    "difference": 2.4717145550711592,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2023-01-12T14:00:00.000+01:00",
-                                    "energy": 0.8309,
-                                    "total": 1.1756,
-                                    "tax": 0.3447,
-                                    "difference": 6.683056789636169,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2023-01-12T15:00:00.000+01:00",
-                                    "energy": 1.0464,
-                                    "total": 1.445,
-                                    "tax": 0.3986,
-                                    "difference": 34.35208884904958,
+                                    "time": "2026-06-08T06:00:00.000+02:00",
+                                    "energy": 1.2802,
+                                    "total": 1.7163,
+                                    "tax": 0.4361,
+                                    "difference": 31.20518817231087,
                                     "level": "HIGH"
                                 },
                                 {
-                                    "time": "2023-01-12T16:00:00.000+01:00",
-                                    "energy": 1.0893,
-                                    "total": 1.4986,
-                                    "tax": 0.4093,
-                                    "difference": 39.86021634486781,
+                                    "time": "2026-06-08T07:00:00.000+02:00",
+                                    "energy": 1.5269,
+                                    "total": 2.0246,
+                                    "tax": 0.4977,
+                                    "difference": 56.48898751781087,
                                     "level": "HIGH"
                                 },
                                 {
-                                    "time": "2023-01-12T17:00:00.000+01:00",
-                                    "energy": 1.2384,
-                                    "total": 1.685,
-                                    "tax": 0.4466,
-                                    "difference": 59.00384827089351,
+                                    "time": "2026-06-08T08:00:00.000+02:00",
+                                    "energy": 1.375,
+                                    "total": 1.8348,
+                                    "tax": 0.4598,
+                                    "difference": 40.92105431723749,
                                     "level": "HIGH"
                                 },
                                 {
-                                    "time": "2023-01-12T18:00:00.000+01:00",
-                                    "energy": 1.3137,
-                                    "total": 1.7791,
-                                    "tax": 0.4654,
-                                    "difference": 68.67196016914795,
+                                    "time": "2026-06-08T09:00:00.000+02:00",
+                                    "energy": 1.1858,
+                                    "total": 1.5982,
+                                    "tax": 0.4124,
+                                    "difference": 21.53031724318562,
                                     "level": "HIGH"
                                 },
                                 {
-                                    "time": "2023-01-12T19:00:00.000+01:00",
-                                    "energy": 1.1081,
-                                    "total": 1.5221,
-                                    "tax": 0.414,
-                                    "difference": 42.27403445492337,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-12T20:00:00.000+01:00",
-                                    "energy": 0.8345,
-                                    "total": 1.1801,
-                                    "tax": 0.3456,
-                                    "difference": 7.1452772787957315,
+                                    "time": "2026-06-08T10:00:00.000+02:00",
+                                    "energy": 1.0489,
+                                    "total": 1.4271,
+                                    "tax": 0.3782,
+                                    "difference": 7.499704635163937,
                                     "level": "NORMAL"
                                 },
                                 {
-                                    "time": "2023-01-12T21:00:00.000+01:00",
-                                    "energy": 0.8392,
-                                    "total": 1.186,
-                                    "tax": 0.3468,
-                                    "difference": 7.748731806309621,
+                                    "time": "2026-06-08T11:00:00.000+02:00",
+                                    "energy": 0.9123,
+                                    "total": 1.2564,
+                                    "tax": 0.3441,
+                                    "difference": -6.500161561006706,
                                     "level": "NORMAL"
                                 },
                                 {
-                                    "time": "2023-01-12T22:00:00.000+01:00",
-                                    "energy": 0.7529,
-                                    "total": 1.0782,
-                                    "tax": 0.3253,
-                                    "difference": -3.3317204754879413,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2023-01-12T23:00:00.000+01:00",
-                                    "energy": 0.4786,
-                                    "total": 0.7353,
-                                    "tax": 0.2567,
-                                    "difference": -38.55035385784106,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-13T00:00:00.000+01:00",
-                                    "energy": 0.3681,
-                                    "total": 0.5971,
-                                    "tax": 0.229,
-                                    "difference": -52.737954983433546,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-13T01:00:00.000+01:00",
-                                    "energy": 0.2466,
-                                    "total": 0.4453,
-                                    "tax": 0.1987,
-                                    "difference": -68.33789649256917,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-13T02:00:00.000+01:00",
-                                    "energy": 0.1865,
-                                    "total": 0.3701,
-                                    "tax": 0.1836,
-                                    "difference": -76.05441076992761,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-13T03:00:00.000+01:00",
-                                    "energy": 0.2082,
-                                    "total": 0.3972,
-                                    "tax": 0.189,
-                                    "difference": -73.26824837693796,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-13T04:00:00.000+01:00",
-                                    "energy": 0.2799,
-                                    "total": 0.4868,
-                                    "tax": 0.2069,
-                                    "difference": -64.0623569678431,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-13T05:00:00.000+01:00",
-                                    "energy": 0.3419,
-                                    "total": 0.5644,
-                                    "tax": 0.2225,
-                                    "difference": -56.10189298787267,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-13T06:00:00.000+01:00",
-                                    "energy": 0.6325,
-                                    "total": 0.9276,
-                                    "tax": 0.2951,
-                                    "difference": -18.790427946269276,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-13T07:00:00.000+01:00",
-                                    "energy": 0.9672,
-                                    "total": 1.346,
-                                    "tax": 0.3788,
-                                    "difference": 24.183238087538925,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-13T08:00:00.000+01:00",
-                                    "energy": 1.078,
-                                    "total": 1.4845,
-                                    "tax": 0.4065,
-                                    "difference": 38.409357587228044,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-13T09:00:00.000+01:00",
-                                    "energy": 1.1077,
-                                    "total": 1.5216,
-                                    "tax": 0.4139,
-                                    "difference": 42.222676622794495,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-13T10:00:00.000+01:00",
-                                    "energy": 1.044,
-                                    "total": 1.442,
-                                    "tax": 0.398,
-                                    "difference": 34.04394185627652,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-13T11:00:00.000+01:00",
-                                    "energy": 0.9577,
-                                    "total": 1.3341,
-                                    "tax": 0.3764,
-                                    "difference": 22.963489574478928,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-13T12:00:00.000+01:00",
-                                    "energy": 0.863,
-                                    "total": 1.2157,
-                                    "tax": 0.3527,
-                                    "difference": 10.804522817975709,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-13T13:00:00.000+01:00",
-                                    "energy": 0.8116,
-                                    "total": 1.1515,
-                                    "tax": 0.3399,
-                                    "difference": 4.205041389419549,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2023-01-13T14:00:00.000+01:00",
-                                    "energy": 0.8498,
-                                    "total": 1.1992,
+                                    "time": "2026-06-08T12:00:00.000+02:00",
+                                    "energy": 0.9337,
+                                    "total": 1.2831,
                                     "tax": 0.3494,
-                                    "difference": 9.109714357723917,
+                                    "difference": -4.306917515632975,
                                     "level": "NORMAL"
                                 },
                                 {
-                                    "time": "2023-01-13T15:00:00.000+01:00",
-                                    "energy": 0.9226,
-                                    "total": 1.2903,
-                                    "tax": 0.3677,
-                                    "difference": 18.456839805173104,
+                                    "time": "2026-06-08T13:00:00.000+02:00",
+                                    "energy": 0.8898,
+                                    "total": 1.2283,
+                                    "tax": 0.3385,
+                                    "difference": -8.806142449834226,
+                                    "level": "NORMAL"
+                                },
+                                {
+                                    "time": "2026-06-08T14:00:00.000+02:00",
+                                    "energy": 0.9065,
+                                    "total": 1.2492,
+                                    "tax": 0.3427,
+                                    "difference": -7.094592190126704,
+                                    "level": "NORMAL"
+                                },
+                                {
+                                    "time": "2026-06-08T15:00:00.000+02:00",
+                                    "energy": 1.005,
+                                    "total": 1.3723,
+                                    "tax": 0.3673,
+                                    "difference": 3.0004797009626714,
+                                    "level": "NORMAL"
+                                },
+                                {
+                                    "time": "2026-06-08T16:00:00.000+02:00",
+                                    "energy": 1.1275,
+                                    "total": 1.5254,
+                                    "tax": 0.3979,
+                                    "difference": 15.555264540134743,
                                     "level": "HIGH"
                                 },
                                 {
-                                    "time": "2023-01-13T16:00:00.000+01:00",
-                                    "energy": 0.962,
-                                    "total": 1.3395,
-                                    "tax": 0.3775,
-                                    "difference": 23.515586269863988,
+                                    "time": "2026-06-08T17:00:00.000+02:00",
+                                    "energy": 1.3627,
+                                    "total": 1.8194,
+                                    "tax": 0.4567,
+                                    "difference": 39.66045143134514,
                                     "level": "HIGH"
                                 },
                                 {
-                                    "time": "2023-01-13T17:00:00.000+01:00",
-                                    "energy": 1.0927,
-                                    "total": 1.5029,
-                                    "tax": 0.4102,
-                                    "difference": 40.296757917962964,
+                                    "time": "2026-06-08T18:00:00.000+02:00",
+                                    "energy": 1.629,
+                                    "total": 2.1523,
+                                    "tax": 0.5233,
+                                    "difference": 66.95301635111264,
                                     "level": "HIGH"
                                 },
                                 {
-                                    "time": "2023-01-13T18:00:00.000+01:00",
-                                    "energy": 1.0848,
-                                    "total": 1.493,
-                                    "tax": 0.4082,
-                                    "difference": 39.282440733418355,
+                                    "time": "2026-06-08T19:00:00.000+02:00",
+                                    "energy": 2.0519,
+                                    "total": 2.6808,
+                                    "tax": 0.6289,
+                                    "difference": 110.29520825711973,
                                     "level": "HIGH"
                                 },
                                 {
-                                    "time": "2023-01-13T19:00:00.000+01:00",
-                                    "energy": 1.027,
-                                    "total": 1.4207,
-                                    "tax": 0.3937,
-                                    "difference": 31.861233990800713,
+                                    "time": "2026-06-08T20:00:00.000+02:00",
+                                    "energy": 2.0151,
+                                    "total": 2.6349,
+                                    "tax": 0.6198,
+                                    "difference": 106.52364840339294,
                                     "level": "HIGH"
                                 },
                                 {
-                                    "time": "2023-01-13T20:00:00.000+01:00",
-                                    "energy": 0.9578,
-                                    "total": 1.3343,
-                                    "tax": 0.3765,
-                                    "difference": 22.976329032511146,
+                                    "time": "2026-06-08T21:00:00.000+02:00",
+                                    "energy": 1.8638,
+                                    "total": 2.4458,
+                                    "tax": 0.582,
+                                    "difference": 91.01720802652162,
                                     "level": "HIGH"
                                 },
                                 {
-                                    "time": "2023-01-13T21:00:00.000+01:00",
-                                    "energy": 0.867,
-                                    "total": 1.2208,
-                                    "tax": 0.3538,
-                                    "difference": 11.318101139264101,
+                                    "time": "2026-06-08T22:00:00.000+02:00",
+                                    "energy": 1.5232,
+                                    "total": 2.02,
+                                    "tax": 0.4968,
+                                    "difference": 56.10978177164813,
                                     "level": "HIGH"
                                 },
                                 {
-                                    "time": "2023-01-13T22:00:00.000+01:00",
-                                    "energy": 0.8628,
-                                    "total": 1.2154,
-                                    "tax": 0.3526,
-                                    "difference": 10.778843901911287,
+                                    "time": "2026-06-08T23:00:00.000+02:00",
+                                    "energy": 1.2178,
+                                    "total": 1.6383,
+                                    "tax": 0.4205,
+                                    "difference": 24.80993450729588,
                                     "level": "HIGH"
                                 },
                                 {
-                                    "time": "2023-01-13T23:00:00.000+01:00",
-                                    "energy": 0.7702,
-                                    "total": 1.0997,
-                                    "tax": 0.3295,
-                                    "difference": -1.110494235915553,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2023-01-14T00:00:00.000+01:00",
-                                    "energy": 0.5594,
-                                    "total": 0.8363,
-                                    "tax": 0.2769,
-                                    "difference": -28.17607176781506,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-14T01:00:00.000+01:00",
-                                    "energy": 0.4978,
-                                    "total": 0.7593,
-                                    "tax": 0.2615,
-                                    "difference": -36.085177915656665,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-14T02:00:00.000+01:00",
-                                    "energy": 0.511,
-                                    "total": 0.7758,
-                                    "tax": 0.2648,
-                                    "difference": -34.390369455404894,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-14T03:00:00.000+01:00",
-                                    "energy": 0.4755,
-                                    "total": 0.7313,
-                                    "tax": 0.2558,
-                                    "difference": -38.948377056839576,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-14T04:00:00.000+01:00",
-                                    "energy": 0.4693,
-                                    "total": 0.7236,
-                                    "tax": 0.2543,
-                                    "difference": -39.74442345483662,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-14T05:00:00.000+01:00",
-                                    "energy": 0.469,
-                                    "total": 0.7233,
-                                    "tax": 0.2543,
-                                    "difference": -39.78294182893326,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-14T06:00:00.000+01:00",
-                                    "energy": 0.5075,
-                                    "total": 0.7714,
-                                    "tax": 0.2639,
-                                    "difference": -34.83975048653227,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-14T07:00:00.000+01:00",
-                                    "energy": 0.6009,
-                                    "total": 0.8882,
-                                    "tax": 0.2873,
-                                    "difference": -22.847696684447754,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-14T08:00:00.000+01:00",
-                                    "energy": 0.6035,
-                                    "total": 0.8914,
-                                    "tax": 0.2879,
-                                    "difference": -22.513870775610272,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-14T09:00:00.000+01:00",
-                                    "energy": 0.6402,
-                                    "total": 0.9373,
-                                    "tax": 0.2971,
-                                    "difference": -17.80178967778906,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-14T10:00:00.000+01:00",
-                                    "energy": 0.7508,
-                                    "total": 1.0755,
-                                    "tax": 0.3247,
-                                    "difference": -3.6013490941643624,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2023-01-14T11:00:00.000+01:00",
-                                    "energy": 0.7378,
-                                    "total": 1.0592,
-                                    "tax": 0.3214,
-                                    "difference": -5.270478638351719,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2023-01-14T12:00:00.000+01:00",
-                                    "energy": 0.7359,
-                                    "total": 1.0568,
-                                    "tax": 0.3209,
-                                    "difference": -5.514428340963718,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2023-01-14T13:00:00.000+01:00",
-                                    "energy": 0.7055,
-                                    "total": 1.0188,
-                                    "tax": 0.3133,
-                                    "difference": -9.417623582755681,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2023-01-14T14:00:00.000+01:00",
-                                    "energy": 0.7535,
-                                    "total": 1.0789,
-                                    "tax": 0.3254,
-                                    "difference": -3.2546837272946902,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2023-01-14T15:00:00.000+01:00",
-                                    "energy": 0.8324,
-                                    "total": 1.1775,
-                                    "tax": 0.3451,
-                                    "difference": 6.87564866011931,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2023-01-14T16:00:00.000+01:00",
-                                    "energy": 0.8542,
-                                    "total": 1.2048,
-                                    "tax": 0.3506,
-                                    "difference": 9.67465051114118,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2023-01-14T17:00:00.000+01:00",
-                                    "energy": 0.8286,
-                                    "total": 1.1727,
-                                    "tax": 0.3441,
-                                    "difference": 6.387749254895311,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2023-01-14T18:00:00.000+01:00",
-                                    "energy": 0.7822,
-                                    "total": 1.1148,
-                                    "tax": 0.3326,
-                                    "difference": 0.4302407279497089,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2023-01-14T19:00:00.000+01:00",
-                                    "energy": 0.7057,
-                                    "total": 1.0191,
-                                    "tax": 0.3134,
-                                    "difference": -9.39194466669126,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2023-01-14T20:00:00.000+01:00",
-                                    "energy": 0.5799,
-                                    "total": 0.8619,
-                                    "tax": 0.282,
-                                    "difference": -25.543982871211938,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-14T21:00:00.000+01:00",
-                                    "energy": 0.4916,
-                                    "total": 0.7514,
-                                    "tax": 0.2598,
-                                    "difference": -36.8812243136537,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-14T22:00:00.000+01:00",
-                                    "energy": 0.4507,
-                                    "total": 0.7004,
-                                    "tax": 0.2497,
-                                    "difference": -42.13256264882775,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-14T23:00:00.000+01:00",
-                                    "energy": 0.3975,
-                                    "total": 0.6338,
-                                    "tax": 0.2363,
-                                    "difference": -48.963154321963685,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-15T00:00:00.000+01:00",
-                                    "energy": 0.3086,
-                                    "total": 0.5227,
-                                    "tax": 0.2141,
-                                    "difference": -60.37743251259873,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-15T01:00:00.000+01:00",
-                                    "energy": 0.3066,
-                                    "total": 0.5203,
-                                    "tax": 0.2137,
-                                    "difference": -60.63422167324293,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-15T02:00:00.000+01:00",
-                                    "energy": 0.2734,
-                                    "total": 0.4788,
-                                    "tax": 0.2054,
-                                    "difference": -64.89692173993679,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-15T03:00:00.000+01:00",
-                                    "energy": 0.1464,
-                                    "total": 0.32,
-                                    "tax": 0.1736,
-                                    "difference": -81.20303344084398,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-15T04:00:00.000+01:00",
-                                    "energy": 0.0899,
-                                    "total": 0.2493,
-                                    "tax": 0.1594,
-                                    "difference": -88.45732722904286,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-15T05:00:00.000+01:00",
-                                    "energy": 0.0546,
-                                    "total": 0.2053,
-                                    "tax": 0.1507,
-                                    "difference": -92.98965591441312,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-15T06:00:00.000+01:00",
-                                    "energy": 0.0681,
-                                    "total": 0.2222,
-                                    "tax": 0.1541,
-                                    "difference": -91.25632908006472,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-15T07:00:00.000+01:00",
-                                    "energy": 0.1136,
-                                    "total": 0.279,
-                                    "tax": 0.1654,
-                                    "difference": -85.41437567540899,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-15T08:00:00.000+01:00",
-                                    "energy": 0.158,
-                                    "total": 0.3345,
-                                    "tax": 0.1765,
-                                    "difference": -79.71365630910758,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-15T09:00:00.000+01:00",
-                                    "energy": 0.2148,
-                                    "total": 0.4054,
-                                    "tax": 0.1906,
-                                    "difference": -72.42084414681207,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-15T10:00:00.000+01:00",
-                                    "energy": 0.2008,
-                                    "total": 0.388,
-                                    "tax": 0.1872,
-                                    "difference": -74.21836827132152,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-15T11:00:00.000+01:00",
-                                    "energy": 0.1318,
-                                    "total": 0.3017,
-                                    "tax": 0.1699,
-                                    "difference": -83.0775943135467,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-15T12:00:00.000+01:00",
-                                    "energy": 0.078,
-                                    "total": 0.2346,
-                                    "tax": 0.1566,
-                                    "difference": -89.98522273487589,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-15T13:00:00.000+01:00",
-                                    "energy": 0.068,
-                                    "total": 0.222,
-                                    "tax": 0.154,
-                                    "difference": -91.26916853809693,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-15T14:00:00.000+01:00",
-                                    "energy": 0.0686,
-                                    "total": 0.2227,
-                                    "tax": 0.1541,
-                                    "difference": -91.19213178990367,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-15T15:00:00.000+01:00",
-                                    "energy": 0.2151,
-                                    "total": 0.4058,
-                                    "tax": 0.1907,
-                                    "difference": -72.38232577271545,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-15T16:00:00.000+01:00",
-                                    "energy": 0.3089,
-                                    "total": 0.5231,
-                                    "tax": 0.2142,
-                                    "difference": -60.33891413850209,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-15T17:00:00.000+01:00",
-                                    "energy": 0.348,
-                                    "total": 0.572,
-                                    "tax": 0.224,
-                                    "difference": -55.31868604790783,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-15T18:00:00.000+01:00",
-                                    "energy": 0.3109,
-                                    "total": 0.5256,
-                                    "tax": 0.2147,
-                                    "difference": -60.08212497785789,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-15T19:00:00.000+01:00",
-                                    "energy": 0.2917,
-                                    "total": 0.5016,
-                                    "tax": 0.2099,
-                                    "difference": -62.54730092004228,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-15T20:00:00.000+01:00",
-                                    "energy": 0.1404,
-                                    "total": 0.3125,
-                                    "tax": 0.1721,
-                                    "difference": -81.9734009227766,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-15T21:00:00.000+01:00",
-                                    "energy": 0.2341,
-                                    "total": 0.4296,
-                                    "tax": 0.1955,
-                                    "difference": -69.94282874659547,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-15T22:00:00.000+01:00",
-                                    "energy": 0.3495,
-                                    "total": 0.5739,
-                                    "tax": 0.2244,
-                                    "difference": -55.126094177424676,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-15T23:00:00.000+01:00",
-                                    "energy": 0.3646,
-                                    "total": 0.5928,
-                                    "tax": 0.2282,
-                                    "difference": -53.18733601456091,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-16T00:00:00.000+01:00",
-                                    "energy": 0.3981,
-                                    "total": 0.6346,
-                                    "tax": 0.2365,
-                                    "difference": -48.88611757377043,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-16T01:00:00.000+01:00",
-                                    "energy": 0.4069,
-                                    "total": 0.6456,
-                                    "tax": 0.2387,
-                                    "difference": -47.75624526693591,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-16T02:00:00.000+01:00",
-                                    "energy": 0.4069,
-                                    "total": 0.6456,
-                                    "tax": 0.2387,
-                                    "difference": -47.75624526693591,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-16T03:00:00.000+01:00",
-                                    "energy": 0.4343,
-                                    "total": 0.6799,
-                                    "tax": 0.2456,
-                                    "difference": -44.238233766110255,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-16T04:00:00.000+01:00",
-                                    "energy": 0.4708,
-                                    "total": 0.7255,
-                                    "tax": 0.2547,
-                                    "difference": -39.55183158435347,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-16T05:00:00.000+01:00",
-                                    "energy": 0.5134,
-                                    "total": 0.7787,
-                                    "tax": 0.2653,
-                                    "difference": -34.08222246263183,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-16T06:00:00.000+01:00",
-                                    "energy": 0.7524,
-                                    "total": 1.0774,
-                                    "tax": 0.325,
-                                    "difference": -3.3959177656490027,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2023-01-16T07:00:00.000+01:00",
-                                    "energy": 0.9755,
-                                    "total": 1.3564,
-                                    "tax": 0.3809,
-                                    "difference": 25.248913104212406,
+                                    "time": "2026-06-09T00:00:00.000+02:00",
+                                    "energy": 1.2146,
+                                    "total": 1.6343,
+                                    "tax": 0.4197,
+                                    "difference": 24.481972780884846,
                                     "level": "HIGH"
                                 },
                                 {
-                                    "time": "2023-01-16T08:00:00.000+01:00",
-                                    "energy": 1.0061,
-                                    "total": 1.3946,
+                                    "time": "2026-06-09T01:00:00.000+02:00",
+                                    "energy": 1.1464,
+                                    "total": 1.5489,
+                                    "tax": 0.4025,
+                                    "difference": 17.492288486749885,
+                                    "level": "HIGH"
+                                },
+                                {
+                                    "time": "2026-06-09T02:00:00.000+02:00",
+                                    "energy": 1.0902,
+                                    "total": 1.4787,
                                     "tax": 0.3885,
-                                    "difference": 29.17778726206876,
+                                    "difference": 11.732460666656237,
                                     "level": "HIGH"
                                 },
                                 {
-                                    "time": "2023-01-16T09:00:00.000+01:00",
-                                    "energy": 1.0243,
-                                    "total": 1.4174,
-                                    "tax": 0.3931,
-                                    "difference": 31.51456862393104,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-16T10:00:00.000+01:00",
-                                    "energy": 1.1118,
-                                    "total": 1.5268,
-                                    "tax": 0.415,
-                                    "difference": 42.749094402115134,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-16T11:00:00.000+01:00",
-                                    "energy": 1.1191,
-                                    "total": 1.5359,
-                                    "tax": 0.4168,
-                                    "difference": 43.68637483846652,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-16T12:00:00.000+01:00",
-                                    "energy": 1.0135,
-                                    "total": 1.4039,
-                                    "tax": 0.3904,
-                                    "difference": 30.127907156452352,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-16T13:00:00.000+01:00",
-                                    "energy": 1.2376,
-                                    "total": 1.684,
-                                    "tax": 0.4464,
-                                    "difference": 58.90113260663583,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-16T14:00:00.000+01:00",
-                                    "energy": 1.5412,
-                                    "total": 2.0635,
-                                    "tax": 0.5223,
-                                    "difference": 97.88172719242658,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-16T15:00:00.000+01:00",
-                                    "energy": 1.5897,
-                                    "total": 2.1241,
-                                    "tax": 0.5344,
-                                    "difference": 104.10886433804859,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-16T16:00:00.000+01:00",
-                                    "energy": 1.6457,
-                                    "total": 2.1941,
-                                    "tax": 0.5484,
-                                    "difference": 111.29896083608645,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-16T17:00:00.000+01:00",
-                                    "energy": 1.4629,
-                                    "total": 1.9656,
-                                    "tax": 0.5027,
-                                    "difference": 87.82843155320586,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-16T18:00:00.000+01:00",
-                                    "energy": 1.0012,
-                                    "total": 1.3885,
-                                    "tax": 0.3873,
-                                    "difference": 28.548653818490465,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-16T19:00:00.000+01:00",
-                                    "energy": 0.9013,
-                                    "total": 1.2637,
-                                    "tax": 0.3624,
-                                    "difference": 15.72203524431228,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-16T20:00:00.000+01:00",
-                                    "energy": 0.7422,
-                                    "total": 1.0648,
-                                    "tax": 0.3226,
-                                    "difference": -4.705542484934469,
+                                    "time": "2026-06-09T03:00:00.000+02:00",
+                                    "energy": 1.0665,
+                                    "total": 1.4492,
+                                    "tax": 0.3827,
+                                    "difference": 9.303494130424568,
                                     "level": "NORMAL"
                                 },
                                 {
-                                    "time": "2023-01-16T21:00:00.000+01:00",
-                                    "energy": 0.6722,
-                                    "total": 0.9772,
-                                    "tax": 0.305,
-                                    "difference": -13.693163107481737,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-16T22:00:00.000+01:00",
-                                    "energy": 0.577,
-                                    "total": 0.8583,
-                                    "tax": 0.2813,
-                                    "difference": -25.916327154146032,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-16T23:00:00.000+01:00",
-                                    "energy": 0.5239,
-                                    "total": 0.7918,
-                                    "tax": 0.2679,
-                                    "difference": -32.73407936924974,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-17T00:00:00.000+01:00",
-                                    "energy": 0.5316,
-                                    "total": 0.8015,
-                                    "tax": 0.2699,
-                                    "difference": -31.745441100769554,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-17T01:00:00.000+01:00",
-                                    "energy": 0.4843,
-                                    "total": 0.7424,
-                                    "tax": 0.2581,
-                                    "difference": -37.81850475000507,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-17T02:00:00.000+01:00",
-                                    "energy": 0.4754,
-                                    "total": 0.7313,
-                                    "tax": 0.2559,
-                                    "difference": -38.961216514871786,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-17T03:00:00.000+01:00",
-                                    "energy": 0.4602,
-                                    "total": 0.7122,
-                                    "tax": 0.252,
-                                    "difference": -40.912814135767775,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-17T04:00:00.000+01:00",
-                                    "energy": 0.4694,
-                                    "total": 0.7238,
-                                    "tax": 0.2544,
-                                    "difference": -39.73158399680442,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-17T05:00:00.000+01:00",
-                                    "energy": 0.516,
-                                    "total": 0.782,
-                                    "tax": 0.266,
-                                    "difference": -33.748396553794365,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-17T06:00:00.000+01:00",
-                                    "energy": 0.6786,
-                                    "total": 0.9853,
-                                    "tax": 0.3067,
-                                    "difference": -12.87143779342027,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-17T07:00:00.000+01:00",
-                                    "energy": 0.7993,
-                                    "total": 1.1362,
-                                    "tax": 0.3369,
-                                    "difference": 2.6257880514576755,
+                                    "time": "2026-06-09T04:00:00.000+02:00",
+                                    "energy": 1.0644,
+                                    "total": 1.4466,
+                                    "tax": 0.3822,
+                                    "difference": 9.088269247467352,
                                     "level": "NORMAL"
                                 },
                                 {
-                                    "time": "2023-01-17T08:00:00.000+01:00",
-                                    "energy": 0.8275,
-                                    "total": 1.1714,
-                                    "tax": 0.3439,
-                                    "difference": 6.246515216540999,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2023-01-17T09:00:00.000+01:00",
-                                    "energy": 0.8191,
-                                    "total": 1.1608,
-                                    "tax": 0.3417,
-                                    "difference": 5.168000741835343,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2023-01-17T10:00:00.000+01:00",
-                                    "energy": 0.8341,
-                                    "total": 1.1796,
-                                    "tax": 0.3455,
-                                    "difference": 7.093919446666888,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2023-01-17T11:00:00.000+01:00",
-                                    "energy": 0.8589,
-                                    "total": 1.2106,
-                                    "tax": 0.3517,
-                                    "difference": 10.27810503865507,
+                                    "time": "2026-06-09T05:00:00.000+02:00",
+                                    "energy": 1.2108,
+                                    "total": 1.6295,
+                                    "tax": 0.4187,
+                                    "difference": 24.09251823077176,
                                     "level": "HIGH"
                                 },
                                 {
-                                    "time": "2023-01-17T12:00:00.000+01:00",
-                                    "energy": 0.9019,
-                                    "total": 1.2643,
-                                    "tax": 0.3624,
-                                    "difference": 15.799071992505546,
+                                    "time": "2026-06-09T06:00:00.000+02:00",
+                                    "energy": 1.4147,
+                                    "total": 1.8843,
+                                    "tax": 0.4696,
+                                    "difference": 44.9898294855243,
                                     "level": "HIGH"
                                 },
                                 {
-                                    "time": "2023-01-17T13:00:00.000+01:00",
-                                    "energy": 0.8472,
-                                    "total": 1.196,
-                                    "tax": 0.3488,
-                                    "difference": 8.775888448886434,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2023-01-17T14:00:00.000+01:00",
-                                    "energy": 0.8144,
-                                    "total": 1.1551,
-                                    "tax": 0.3407,
-                                    "difference": 4.564546214321453,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2023-01-17T15:00:00.000+01:00",
-                                    "energy": 0.8524,
-                                    "total": 1.2024,
-                                    "tax": 0.35,
-                                    "difference": 9.4435402665614,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2023-01-17T16:00:00.000+01:00",
-                                    "energy": 0.8575,
-                                    "total": 1.2089,
-                                    "tax": 0.3514,
-                                    "difference": 10.098352626204132,
+                                    "time": "2026-06-09T07:00:00.000+02:00",
+                                    "energy": 1.5077,
+                                    "total": 2.0006,
+                                    "tax": 0.4929,
+                                    "difference": 54.52121715934473,
                                     "level": "HIGH"
                                 },
                                 {
-                                    "time": "2023-01-17T17:00:00.000+01:00",
-                                    "energy": 0.8635,
-                                    "total": 1.2164,
-                                    "tax": 0.3529,
-                                    "difference": 10.868720108136756,
+                                    "time": "2026-06-09T08:00:00.000+02:00",
+                                    "energy": 1.3918,
+                                    "total": 1.8558,
+                                    "tax": 0.464,
+                                    "difference": 42.64285338089536,
                                     "level": "HIGH"
                                 },
                                 {
-                                    "time": "2023-01-17T18:00:00.000+01:00",
-                                    "energy": 0.8286,
-                                    "total": 1.1727,
-                                    "tax": 0.3441,
-                                    "difference": 6.387749254895311,
+                                    "time": "2026-06-09T09:00:00.000+02:00",
+                                    "energy": 1.2016,
+                                    "total": 1.618,
+                                    "tax": 0.4164,
+                                    "difference": 23.149628267340063,
+                                    "level": "HIGH"
+                                },
+                                {
+                                    "time": "2026-06-09T10:00:00.000+02:00",
+                                    "energy": 0.9272,
+                                    "total": 1.2751,
+                                    "tax": 0.3479,
+                                    "difference": -4.973089772405373,
                                     "level": "NORMAL"
                                 },
                                 {
-                                    "time": "2023-01-17T19:00:00.000+01:00",
-                                    "energy": 0.7578,
-                                    "total": 1.0843,
-                                    "tax": 0.3265,
-                                    "difference": -2.70258703190963,
+                                    "time": "2026-06-09T11:00:00.000+02:00",
+                                    "energy": 0.7007,
+                                    "total": 0.9919,
+                                    "tax": 0.2912,
+                                    "difference": -28.186630719935764,
+                                    "level": "LOW"
+                                },
+                                {
+                                    "time": "2026-06-09T12:00:00.000+02:00",
+                                    "energy": 0.4163,
+                                    "total": 0.6364,
+                                    "tax": 0.2201,
+                                    "difference": -57.33422915471566,
+                                    "level": "LOW"
+                                },
+                                {
+                                    "time": "2026-06-09T13:00:00.000+02:00",
+                                    "energy": 0.4145,
+                                    "total": 0.6341,
+                                    "tax": 0.2196,
+                                    "difference": -57.51870762582186,
+                                    "level": "LOW"
+                                },
+                                {
+                                    "time": "2026-06-09T14:00:00.000+02:00",
+                                    "energy": 0.3937,
+                                    "total": 0.6081,
+                                    "tax": 0.2144,
+                                    "difference": -59.650458847493525,
+                                    "level": "LOW"
+                                },
+                                {
+                                    "time": "2026-06-09T15:00:00.000+02:00",
+                                    "energy": 0.3973,
+                                    "total": 0.6126,
+                                    "tax": 0.2153,
+                                    "difference": -59.28150190528112,
+                                    "level": "LOW"
+                                },
+                                {
+                                    "time": "2026-06-09T16:00:00.000+02:00",
+                                    "energy": 0.4731,
+                                    "total": 0.7074,
+                                    "tax": 0.2343,
+                                    "difference": -51.51290851091995,
+                                    "level": "LOW"
+                                },
+                                {
+                                    "time": "2026-06-09T17:00:00.000+02:00",
+                                    "energy": 0.879,
+                                    "total": 1.2147,
+                                    "tax": 0.3357,
+                                    "difference": -9.913013276471446,
                                     "level": "NORMAL"
                                 },
                                 {
-                                    "time": "2023-01-17T20:00:00.000+01:00",
-                                    "energy": 0.6783,
-                                    "total": 0.9849,
-                                    "tax": 0.3066,
-                                    "difference": -12.909956167516896,
+                                    "time": "2026-06-09T18:00:00.000+02:00",
+                                    "energy": 1.3234,
+                                    "total": 1.7702,
+                                    "tax": 0.4468,
+                                    "difference": 35.63267147885972,
+                                    "level": "HIGH"
+                                },
+                                {
+                                    "time": "2026-06-09T19:00:00.000+02:00",
+                                    "energy": 1.4032,
+                                    "total": 1.87,
+                                    "tax": 0.4668,
+                                    "difference": 43.81121703123466,
+                                    "level": "HIGH"
+                                },
+                                {
+                                    "time": "2026-06-09T20:00:00.000+02:00",
+                                    "energy": 1.363,
+                                    "total": 1.8197,
+                                    "tax": 0.4567,
+                                    "difference": 39.691197843196136,
+                                    "level": "HIGH"
+                                },
+                                {
+                                    "time": "2026-06-09T21:00:00.000+02:00",
+                                    "energy": 1.2134,
+                                    "total": 1.6328,
+                                    "tax": 0.4194,
+                                    "difference": 24.358987133480724,
+                                    "level": "HIGH"
+                                },
+                                {
+                                    "time": "2026-06-09T22:00:00.000+02:00",
+                                    "energy": 1.0722,
+                                    "total": 1.4562,
+                                    "tax": 0.384,
+                                    "difference": 9.887675955594204,
+                                    "level": "NORMAL"
+                                },
+                                {
+                                    "time": "2026-06-09T23:00:00.000+02:00",
+                                    "energy": 0.9642,
+                                    "total": 1.3214,
+                                    "tax": 0.3572,
+                                    "difference": -1.1810323107778942,
+                                    "level": "NORMAL"
+                                },
+                                {
+                                    "time": "2026-06-10T00:00:00.000+02:00",
+                                    "energy": 0.7738,
+                                    "total": 1.0832,
+                                    "tax": 0.3094,
+                                    "difference": -20.6947550322339,
                                     "level": "LOW"
                                 },
                                 {
-                                    "time": "2023-01-17T21:00:00.000+01:00",
-                                    "energy": 0.606,
-                                    "total": 0.8945,
-                                    "tax": 0.2885,
-                                    "difference": -22.19288432480502,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-17T22:00:00.000+01:00",
-                                    "energy": 0.5348,
-                                    "total": 0.8056,
-                                    "tax": 0.2708,
-                                    "difference": -31.33457844373882,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-17T23:00:00.000+01:00",
-                                    "energy": 0.4888,
-                                    "total": 0.748,
-                                    "tax": 0.2592,
-                                    "difference": -37.240729138555594,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-18T00:00:00.000+01:00",
-                                    "energy": 0.45,
-                                    "total": 0.6995,
-                                    "tax": 0.2495,
-                                    "difference": -42.22243885505323,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-18T01:00:00.000+01:00",
-                                    "energy": 0.4375,
-                                    "total": 0.6838,
-                                    "tax": 0.2463,
-                                    "difference": -43.82737110907953,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-18T02:00:00.000+01:00",
-                                    "energy": 0.4369,
-                                    "total": 0.6831,
-                                    "tax": 0.2462,
-                                    "difference": -43.90440785727279,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-18T03:00:00.000+01:00",
-                                    "energy": 0.4327,
-                                    "total": 0.6779,
-                                    "tax": 0.2452,
-                                    "difference": -44.44366509462563,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-18T04:00:00.000+01:00",
-                                    "energy": 0.4822,
-                                    "total": 0.7397,
-                                    "tax": 0.2575,
-                                    "difference": -38.088133368681476,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-18T05:00:00.000+01:00",
-                                    "energy": 0.588,
-                                    "total": 0.872,
+                                    "time": "2026-06-10T01:00:00.000+02:00",
+                                    "energy": 0.6719,
+                                    "total": 0.9559,
                                     "tax": 0.284,
-                                    "difference": -24.503986770602893,
+                                    "difference": -31.138286257635002,
                                     "level": "LOW"
                                 },
                                 {
-                                    "time": "2023-01-18T06:00:00.000+01:00",
-                                    "energy": 0.7543,
-                                    "total": 1.0799,
-                                    "tax": 0.3256,
-                                    "difference": -3.1519680630370033,
+                                    "time": "2026-06-10T02:00:00.000+02:00",
+                                    "energy": 0.7937,
+                                    "total": 1.1081,
+                                    "tax": 0.3144,
+                                    "difference": -18.655243046115345,
+                                    "level": "LOW"
+                                },
+                                {
+                                    "time": "2026-06-10T03:00:00.000+02:00",
+                                    "energy": 0.712,
+                                    "total": 1.006,
+                                    "tax": 0.294,
+                                    "difference": -27.028515873546837,
+                                    "level": "LOW"
+                                },
+                                {
+                                    "time": "2026-06-10T04:00:00.000+02:00",
+                                    "energy": 0.6569,
+                                    "total": 0.9371,
+                                    "tax": 0.2802,
+                                    "difference": -32.67560685018668,
+                                    "level": "LOW"
+                                },
+                                {
+                                    "time": "2026-06-10T05:00:00.000+02:00",
+                                    "energy": 0.6192,
+                                    "total": 0.89,
+                                    "tax": 0.2708,
+                                    "difference": -36.539405939466576,
+                                    "level": "LOW"
+                                },
+                                {
+                                    "time": "2026-06-10T06:00:00.000+02:00",
+                                    "energy": 0.8254,
+                                    "total": 1.1478,
+                                    "tax": 0.3224,
+                                    "difference": -15.406372193856129,
+                                    "level": "LOW"
+                                },
+                                {
+                                    "time": "2026-06-10T07:00:00.000+02:00",
+                                    "energy": 0.9639,
+                                    "total": 1.3209,
+                                    "tax": 0.357,
+                                    "difference": -1.2117787226289352,
                                     "level": "NORMAL"
                                 },
                                 {
-                                    "time": "2023-01-18T07:00:00.000+01:00",
-                                    "energy": 0.9031,
-                                    "total": 1.2658,
-                                    "tax": 0.3627,
-                                    "difference": 15.953145488892062,
-                                    "level": "HIGH"
+                                    "time": "2026-06-10T08:00:00.000+02:00",
+                                    "energy": 0.8202,
+                                    "total": 1.1413,
+                                    "tax": 0.3211,
+                                    "difference": -15.93930999927403,
+                                    "level": "LOW"
                                 },
                                 {
-                                    "time": "2023-01-18T08:00:00.000+01:00",
-                                    "energy": 0.9323,
-                                    "total": 1.3024,
-                                    "tax": 0.3701,
-                                    "difference": 19.70226723429751,
-                                    "level": "HIGH"
+                                    "time": "2026-06-10T09:00:00.000+02:00",
+                                    "energy": 0.5304,
+                                    "total": 0.779,
+                                    "tax": 0.2486,
+                                    "difference": -45.640343847372534,
+                                    "level": "LOW"
                                 },
                                 {
-                                    "time": "2023-01-18T09:00:00.000+01:00",
-                                    "energy": 0.9317,
-                                    "total": 1.3017,
-                                    "tax": 0.37,
-                                    "difference": 19.62523048610423,
-                                    "level": "HIGH"
+                                    "time": "2026-06-10T10:00:00.000+02:00",
+                                    "energy": 0.4247,
+                                    "total": 0.6469,
+                                    "tax": 0.2222,
+                                    "difference": -56.473329622886716,
+                                    "level": "LOW"
                                 },
                                 {
-                                    "time": "2023-01-18T10:00:00.000+01:00",
-                                    "energy": 1.0154,
-                                    "total": 1.4063,
-                                    "tax": 0.3909,
-                                    "difference": 30.371856859064337,
-                                    "level": "HIGH"
+                                    "time": "2026-06-10T11:00:00.000+02:00",
+                                    "energy": 0.2895,
+                                    "total": 0.478,
+                                    "tax": 0.1885,
+                                    "difference": -70.32971256375254,
+                                    "level": "LOW"
                                 },
                                 {
-                                    "time": "2023-01-18T11:00:00.000+01:00",
-                                    "energy": 1.1174,
-                                    "total": 1.5337,
-                                    "tax": 0.4163,
-                                    "difference": 43.468104051918914,
-                                    "level": "HIGH"
+                                    "time": "2026-06-10T12:00:00.000+02:00",
+                                    "energy": 0.2048,
+                                    "total": 0.372,
+                                    "tax": 0.1672,
+                                    "difference": -79.01044950969437,
+                                    "level": "LOW"
                                 },
                                 {
-                                    "time": "2023-01-18T12:00:00.000+01:00",
-                                    "energy": 1.2414,
-                                    "total": 1.6887,
-                                    "tax": 0.4473,
-                                    "difference": 59.389032011859825,
-                                    "level": "HIGH"
+                                    "time": "2026-06-10T13:00:00.000+02:00",
+                                    "energy": 0.1473,
+                                    "total": 0.3001,
+                                    "tax": 0.1528,
+                                    "difference": -84.90351178114248,
+                                    "level": "LOW"
                                 },
                                 {
-                                    "time": "2023-01-18T13:00:00.000+01:00",
-                                    "energy": 1.3499,
-                                    "total": 1.8244,
-                                    "tax": 0.4745,
-                                    "difference": 73.3198439768081,
-                                    "level": "HIGH"
+                                    "time": "2026-06-10T14:00:00.000+02:00",
+                                    "energy": 0.1085,
+                                    "total": 0.2516,
+                                    "tax": 0.1431,
+                                    "difference": -88.88004771387617,
+                                    "level": "LOW"
                                 },
                                 {
-                                    "time": "2023-01-18T14:00:00.000+01:00",
-                                    "energy": 1.3964,
-                                    "total": 1.8825,
-                                    "tax": 0.4861,
-                                    "difference": 79.29019196178595,
-                                    "level": "HIGH"
+                                    "time": "2026-06-10T15:00:00.000+02:00",
+                                    "energy": 0.3134,
+                                    "total": 0.5078,
+                                    "tax": 0.1944,
+                                    "difference": -67.88024841962019,
+                                    "level": "LOW"
                                 },
                                 {
-                                    "time": "2023-01-18T15:00:00.000+01:00",
-                                    "energy": 1.4996,
-                                    "total": 2.0116,
-                                    "tax": 0.512,
-                                    "difference": 92.54051265102709,
-                                    "level": "HIGH"
+                                    "time": "2026-06-10T16:00:00.000+02:00",
+                                    "energy": 0.5707,
+                                    "total": 0.8294,
+                                    "tax": 0.2587,
+                                    "difference": -41.510075855383676,
+                                    "level": "LOW"
                                 },
                                 {
-                                    "time": "2023-01-18T16:00:00.000+01:00",
-                                    "energy": 1.6174,
-                                    "total": 2.1588,
-                                    "tax": 0.5414,
-                                    "difference": 107.66539421297088,
-                                    "level": "HIGH"
+                                    "time": "2026-06-10T17:00:00.000+02:00",
+                                    "energy": 0.7334,
+                                    "total": 1.0328,
+                                    "tax": 0.2994,
+                                    "difference": -24.835271828173106,
+                                    "level": "LOW"
                                 },
                                 {
-                                    "time": "2023-01-18T17:00:00.000+01:00",
-                                    "energy": 1.6812,
-                                    "total": 2.2385,
-                                    "tax": 0.5573,
-                                    "difference": 115.85696843752115,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-18T18:00:00.000+01:00",
-                                    "energy": 1.5525,
-                                    "total": 2.0776,
-                                    "tax": 0.5251,
-                                    "difference": 99.33258595006635,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-18T19:00:00.000+01:00",
-                                    "energy": 1.4357,
-                                    "total": 1.9317,
-                                    "tax": 0.496,
-                                    "difference": 84.33609896844462,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-18T20:00:00.000+01:00",
-                                    "energy": 1.366,
-                                    "total": 1.8446,
-                                    "tax": 0.4786,
-                                    "difference": 75.38699671999399,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-18T21:00:00.000+01:00",
-                                    "energy": 1.354,
-                                    "total": 1.8295,
-                                    "tax": 0.4755,
-                                    "difference": 73.84626175612874,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-18T22:00:00.000+01:00",
-                                    "energy": 0.9293,
-                                    "total": 1.2986,
-                                    "tax": 0.3693,
-                                    "difference": 19.317083493331182,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-18T23:00:00.000+01:00",
-                                    "energy": 0.8556,
-                                    "total": 1.2065,
-                                    "tax": 0.3509,
-                                    "difference": 9.854402923592119,
+                                    "time": "2026-06-10T18:00:00.000+02:00",
+                                    "energy": 0.8869,
+                                    "total": 1.2246,
+                                    "tax": 0.3377,
+                                    "difference": -9.103357764394232,
                                     "level": "NORMAL"
                                 },
                                 {
-                                    "time": "2023-01-19T00:00:00.000+01:00",
-                                    "energy": 0.9333,
-                                    "total": 1.3036,
-                                    "tax": 0.3703,
-                                    "difference": 19.830661814619617,
+                                    "time": "2026-06-10T19:00:00.000+02:00",
+                                    "energy": 1.0531,
+                                    "total": 1.4324,
+                                    "tax": 0.3793,
+                                    "difference": 7.930154401078397,
+                                    "level": "NORMAL"
+                                },
+                                {
+                                    "time": "2026-06-10T20:00:00.000+02:00",
+                                    "energy": 1.1981,
+                                    "total": 1.6137,
+                                    "tax": 0.4156,
+                                    "difference": 22.79092012907799,
                                     "level": "HIGH"
                                 },
                                 {
-                                    "time": "2023-01-19T01:00:00.000+01:00",
-                                    "energy": 0.9279,
-                                    "total": 1.2969,
-                                    "tax": 0.369,
-                                    "difference": 19.13733108088023,
+                                    "time": "2026-06-10T21:00:00.000+02:00",
+                                    "energy": 1.1574,
+                                    "total": 1.5628,
+                                    "tax": 0.4054,
+                                    "difference": 18.61965692128777,
                                     "level": "HIGH"
                                 },
                                 {
-                                    "time": "2023-01-19T02:00:00.000+01:00",
-                                    "energy": 0.9237,
-                                    "total": 1.2916,
-                                    "tax": 0.3679,
-                                    "difference": 18.598073843527402,
-                                    "level": "HIGH"
+                                    "time": "2026-06-10T22:00:00.000+02:00",
+                                    "energy": 1.0412,
+                                    "total": 1.4174,
+                                    "tax": 0.3762,
+                                    "difference": 6.710546730987389,
+                                    "level": "NORMAL"
                                 },
                                 {
-                                    "time": "2023-01-19T03:00:00.000+01:00",
-                                    "energy": 0.9485,
-                                    "total": 1.3226,
-                                    "tax": 0.3741,
-                                    "difference": 21.7822594355156,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-19T04:00:00.000+01:00",
-                                    "energy": 1.037,
-                                    "total": 1.4332,
-                                    "tax": 0.3962,
-                                    "difference": 33.14517979402177,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-19T05:00:00.000+01:00",
-                                    "energy": 1.1723,
-                                    "total": 1.6024,
-                                    "tax": 0.4301,
-                                    "difference": 50.51696651160242,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-19T06:00:00.000+01:00",
-                                    "energy": 1.3204,
-                                    "total": 1.7875,
-                                    "tax": 0.4671,
-                                    "difference": 69.53220385730603,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-19T07:00:00.000+01:00",
-                                    "energy": 1.6711,
-                                    "total": 2.2259,
-                                    "tax": 0.5548,
-                                    "difference": 114.56018317626788,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-19T08:00:00.000+01:00",
-                                    "energy": 1.7863,
-                                    "total": 2.3699,
-                                    "tax": 0.5836,
-                                    "difference": 129.35123882937427,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-19T09:00:00.000+01:00",
-                                    "energy": 1.741,
-                                    "total": 2.3133,
-                                    "tax": 0.5723,
-                                    "difference": 123.53496434078295,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-19T10:00:00.000+01:00",
-                                    "energy": 1.7291,
-                                    "total": 2.2984,
-                                    "tax": 0.5693,
-                                    "difference": 122.00706883494993,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-19T11:00:00.000+01:00",
-                                    "energy": 1.5484,
-                                    "total": 2.0725,
-                                    "tax": 0.5241,
-                                    "difference": 98.80616817074574,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-19T12:00:00.000+01:00",
-                                    "energy": 1.636,
-                                    "total": 2.1819,
-                                    "tax": 0.5459,
-                                    "difference": 110.05353340696203,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-19T13:00:00.000+01:00",
-                                    "energy": 1.6883,
-                                    "total": 2.2474,
-                                    "tax": 0.5591,
-                                    "difference": 116.76856995780804,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-19T14:00:00.000+01:00",
-                                    "energy": 1.7351,
-                                    "total": 2.3059,
-                                    "tax": 0.5708,
-                                    "difference": 122.77743631688253,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-19T15:00:00.000+01:00",
-                                    "energy": 1.9024,
-                                    "total": 2.5151,
-                                    "tax": 0.6127,
-                                    "difference": 144.2578496047705,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-19T16:00:00.000+01:00",
-                                    "energy": 2.0141,
-                                    "total": 2.6547,
-                                    "tax": 0.6406,
-                                    "difference": 158.59952422674957,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-19T17:00:00.000+01:00",
-                                    "energy": 1.9406,
-                                    "total": 2.5628,
-                                    "tax": 0.6222,
-                                    "difference": 149.1625225730749,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-19T18:00:00.000+01:00",
-                                    "energy": 1.7492,
-                                    "total": 2.3235,
-                                    "tax": 0.5743,
-                                    "difference": 124.58779989942423,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-19T19:00:00.000+01:00",
-                                    "energy": 1.6927,
-                                    "total": 2.2529,
-                                    "tax": 0.5602,
-                                    "difference": 117.33350611122532,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-19T20:00:00.000+01:00",
-                                    "energy": 1.6268,
-                                    "total": 2.1705,
-                                    "tax": 0.5437,
-                                    "difference": 108.87230326799872,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-19T21:00:00.000+01:00",
-                                    "energy": 1.6046,
-                                    "total": 2.1427,
-                                    "tax": 0.5381,
-                                    "difference": 106.02194358484795,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-19T22:00:00.000+01:00",
-                                    "energy": 1.3291,
-                                    "total": 1.7984,
-                                    "tax": 0.4693,
-                                    "difference": 70.64923670610835,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-19T23:00:00.000+01:00",
-                                    "energy": 1.1863,
-                                    "total": 1.6198,
-                                    "tax": 0.4335,
-                                    "difference": 52.314490636111884,
-                                    "level": "HIGH"
+                                    "time": "2026-06-10T23:00:00.000+02:00",
+                                    "energy": 0.9194,
+                                    "total": 1.2653,
+                                    "tax": 0.3459,
+                                    "difference": -5.772496480532254,
+                                    "level": "NORMAL"
                                 }
                             ]
                         },
                         "daily": {
-                            "minEnergy": 0.0968,
-                            "maxEnergy": 2.3178,
-                            "minTotal": 0.2304,
-                            "maxTotal": 3.0067,
+                            "minEnergy": 0.1905,
+                            "maxEnergy": 1.4159,
+                            "minTotal": 0.3541,
+                            "maxTotal": 1.8859,
                             "currency": "SEK",
                             "entries": [
                                 {
-                                    "time": "2022-12-19T00:00:00.000+01:00",
-                                    "energy": 2.0465,
-                                    "total": 2.6675,
-                                    "tax": 0.621,
-                                    "difference": 101.22230381839356,
+                                    "time": "2026-05-11T00:00:00.000+02:00",
+                                    "energy": 1.2143,
+                                    "total": 1.6338,
+                                    "tax": 0.4195,
+                                    "difference": 45.29268273855013,
                                     "level": "HIGH"
                                 },
                                 {
-                                    "time": "2022-12-20T00:00:00.000+01:00",
-                                    "energy": 2.0339,
-                                    "total": 2.6517,
-                                    "tax": 0.6178,
-                                    "difference": 99.9834076404743,
+                                    "time": "2026-05-12T00:00:00.000+02:00",
+                                    "energy": 1.156,
+                                    "total": 1.561,
+                                    "tax": 0.405,
+                                    "difference": 38.317006708197255,
                                     "level": "HIGH"
                                 },
                                 {
-                                    "time": "2022-12-21T00:00:00.000+01:00",
-                                    "energy": 2.3178,
-                                    "total": 3.0067,
-                                    "tax": 0.6889,
-                                    "difference": 127.89790168105185,
+                                    "time": "2026-05-13T00:00:00.000+02:00",
+                                    "energy": 1.0397,
+                                    "total": 1.4157,
+                                    "tax": 0.376,
+                                    "difference": 24.401550064457368,
                                     "level": "HIGH"
                                 },
                                 {
-                                    "time": "2022-12-22T00:00:00.000+01:00",
-                                    "energy": 2.0752,
-                                    "total": 2.7034,
-                                    "tax": 0.6282,
-                                    "difference": 104.0442340014319,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2022-12-23T00:00:00.000+01:00",
-                                    "energy": 1.8635,
-                                    "total": 2.4388,
-                                    "tax": 0.5753,
-                                    "difference": 83.22881171051864,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2022-12-24T00:00:00.000+01:00",
-                                    "energy": 1.2575,
-                                    "total": 1.6812,
-                                    "tax": 0.4237,
-                                    "difference": 23.643805058211527,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2022-12-25T00:00:00.000+01:00",
-                                    "energy": 1.0743,
-                                    "total": 1.4523,
-                                    "tax": 0.378,
-                                    "difference": 5.630647931639501,
-                                    "level": "NORMAL"
-                                },
-                                {
-                                    "time": "2022-12-26T00:00:00.000+01:00",
-                                    "energy": 0.3933,
-                                    "total": 0.6009,
-                                    "tax": 0.2076,
-                                    "difference": -61.328740732091774,
+                                    "time": "2026-05-14T00:00:00.000+02:00",
+                                    "energy": 0.5719,
+                                    "total": 0.8309,
+                                    "tax": 0.259,
+                                    "difference": -31.571370124205885,
                                     "level": "LOW"
                                 },
                                 {
-                                    "time": "2022-12-27T00:00:00.000+01:00",
-                                    "energy": 0.8694,
-                                    "total": 1.1962,
+                                    "time": "2026-05-15T00:00:00.000+02:00",
+                                    "energy": 0.9737,
+                                    "total": 1.3332,
+                                    "tax": 0.3595,
+                                    "difference": 16.50455833198241,
+                                    "level": "HIGH"
+                                },
+                                {
+                                    "time": "2026-05-16T00:00:00.000+02:00",
+                                    "energy": 0.9027,
+                                    "total": 1.2444,
+                                    "tax": 0.3417,
+                                    "difference": 8.009309650077554,
+                                    "level": "NORMAL"
+                                },
+                                {
+                                    "time": "2026-05-17T00:00:00.000+02:00",
+                                    "energy": 0.7188,
+                                    "total": 1.0145,
+                                    "tax": 0.2957,
+                                    "difference": -13.994580949954852,
+                                    "level": "LOW"
+                                },
+                                {
+                                    "time": "2026-05-18T00:00:00.000+02:00",
+                                    "energy": 1.264,
+                                    "total": 1.6961,
+                                    "tax": 0.4321,
+                                    "difference": 51.239356815883525,
+                                    "level": "HIGH"
+                                },
+                                {
+                                    "time": "2026-05-19T00:00:00.000+02:00",
+                                    "energy": 1.0104,
+                                    "total": 1.3791,
+                                    "tax": 0.3687,
+                                    "difference": 20.895764340798024,
+                                    "level": "HIGH"
+                                },
+                                {
+                                    "time": "2026-05-20T00:00:00.000+02:00",
+                                    "energy": 0.8614,
+                                    "total": 1.1927,
+                                    "tax": 0.3313,
+                                    "difference": 3.067707247786444,
+                                    "level": "NORMAL"
+                                },
+                                {
+                                    "time": "2026-05-21T00:00:00.000+02:00",
+                                    "energy": 1.0022,
+                                    "total": 1.3688,
+                                    "tax": 0.3666,
+                                    "difference": 19.914622943732965,
+                                    "level": "HIGH"
+                                },
+                                {
+                                    "time": "2026-05-22T00:00:00.000+02:00",
+                                    "energy": 0.9023,
+                                    "total": 1.2438,
+                                    "tax": 0.3415,
+                                    "difference": 7.961449094123168,
+                                    "level": "NORMAL"
+                                },
+                                {
+                                    "time": "2026-05-23T00:00:00.000+02:00",
+                                    "energy": 0.3717,
+                                    "total": 0.5807,
+                                    "tax": 0.209,
+                                    "difference": -55.52557837937982,
+                                    "level": "LOW"
+                                },
+                                {
+                                    "time": "2026-05-24T00:00:00.000+02:00",
+                                    "energy": 0.1905,
+                                    "total": 0.3541,
+                                    "tax": 0.1636,
+                                    "difference": -77.2064102267201,
+                                    "level": "LOW"
+                                },
+                                {
+                                    "time": "2026-05-25T00:00:00.000+02:00",
+                                    "energy": 0.4179,
+                                    "total": 0.6384,
+                                    "tax": 0.2205,
+                                    "difference": -49.997684166647375,
+                                    "level": "LOW"
+                                },
+                                {
+                                    "time": "2026-05-26T00:00:00.000+02:00",
+                                    "energy": 0.4704,
+                                    "total": 0.704,
+                                    "tax": 0.2336,
+                                    "difference": -43.71598619763323,
+                                    "level": "LOW"
+                                },
+                                {
+                                    "time": "2026-05-27T00:00:00.000+02:00",
+                                    "energy": 0.4053,
+                                    "total": 0.6226,
+                                    "tax": 0.2173,
+                                    "difference": -51.50529167921077,
+                                    "level": "LOW"
+                                },
+                                {
+                                    "time": "2026-05-28T00:00:00.000+02:00",
+                                    "energy": 0.6755,
+                                    "total": 0.9604,
+                                    "tax": 0.2849,
+                                    "difference": -19.17548613201795,
+                                    "level": "LOW"
+                                },
+                                {
+                                    "time": "2026-05-29T00:00:00.000+02:00",
+                                    "energy": 0.7428,
+                                    "total": 1.0445,
+                                    "tax": 0.3017,
+                                    "difference": -11.122947592691233,
+                                    "level": "LOW"
+                                },
+                                {
+                                    "time": "2026-05-30T00:00:00.000+02:00",
+                                    "energy": 0.7232,
+                                    "total": 1.02,
+                                    "tax": 0.2968,
+                                    "difference": -13.468114834456529,
+                                    "level": "LOW"
+                                },
+                                {
+                                    "time": "2026-05-31T00:00:00.000+02:00",
+                                    "energy": 0.8942,
+                                    "total": 1.2338,
+                                    "tax": 0.3396,
+                                    "difference": 6.992272836046709,
+                                    "level": "NORMAL"
+                                },
+                                {
+                                    "time": "2026-06-01T00:00:00.000+02:00",
+                                    "energy": 1.4159,
+                                    "total": 1.8859,
+                                    "tax": 0.47,
+                                    "difference": 69.41440293956444,
+                                    "level": "HIGH"
+                                },
+                                {
+                                    "time": "2026-06-02T00:00:00.000+02:00",
+                                    "energy": 1.3097,
+                                    "total": 1.7531,
+                                    "tax": 0.4434,
+                                    "difference": 56.707425333673,
+                                    "level": "HIGH"
+                                },
+                                {
+                                    "time": "2026-06-03T00:00:00.000+02:00",
+                                    "energy": 1.1011,
+                                    "total": 1.4924,
+                                    "tax": 0.3913,
+                                    "difference": 31.748145403456732,
+                                    "level": "HIGH"
+                                },
+                                {
+                                    "time": "2026-06-04T00:00:00.000+02:00",
+                                    "energy": 0.567,
+                                    "total": 0.8248,
+                                    "tax": 0.2578,
+                                    "difference": -32.157661934647194,
+                                    "level": "LOW"
+                                },
+                                {
+                                    "time": "2026-06-05T00:00:00.000+02:00",
+                                    "energy": 0.8798,
+                                    "total": 1.2157,
+                                    "tax": 0.3359,
+                                    "difference": 5.269292821688552,
+                                    "level": "NORMAL"
+                                },
+                                {
+                                    "time": "2026-06-06T00:00:00.000+02:00",
+                                    "energy": 0.8432,
+                                    "total": 1.17,
                                     "tax": 0.3268,
-                                    "difference": -14.516163723571282,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2022-12-28T00:00:00.000+01:00",
-                                    "energy": 0.7843,
-                                    "total": 1.0897,
-                                    "tax": 0.3054,
-                                    "difference": -22.883629179200554,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2022-12-29T00:00:00.000+01:00",
-                                    "energy": 0.2914,
-                                    "total": 0.4737,
-                                    "tax": 0.1823,
-                                    "difference": -71.34806775828005,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2022-12-30T00:00:00.000+01:00",
-                                    "energy": 0.1981,
-                                    "total": 0.3569,
-                                    "tax": 0.1588,
-                                    "difference": -80.52179898049168,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2022-12-31T00:00:00.000+01:00",
-                                    "energy": 0.0968,
-                                    "total": 0.2304,
-                                    "tax": 0.1336,
-                                    "difference": -90.48213095058857,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-01T00:00:00.000+01:00",
-                                    "energy": 0.2038,
-                                    "total": 0.3918,
-                                    "tax": 0.188,
-                                    "difference": -79.96134594762344,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-02T00:00:00.000+01:00",
-                                    "energy": 1.3778,
-                                    "total": 1.8592,
-                                    "tax": 0.4814,
-                                    "difference": 35.47231380453587,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-03T00:00:00.000+01:00",
-                                    "energy": 1.4833,
-                                    "total": 1.9912,
-                                    "tax": 0.5079,
-                                    "difference": 45.845611167272494,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-04T00:00:00.000+01:00",
-                                    "energy": 0.8169,
-                                    "total": 1.1581,
-                                    "tax": 0.3412,
-                                    "difference": -19.678231131568197,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-05T00:00:00.000+01:00",
-                                    "energy": 1.2494,
-                                    "total": 1.6987,
-                                    "tax": 0.4493,
-                                    "difference": 22.84737180097774,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-06T00:00:00.000+01:00",
-                                    "energy": 1.1843,
-                                    "total": 1.6173,
-                                    "tax": 0.433,
-                                    "difference": 16.446408215061552,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-07T00:00:00.000+01:00",
-                                    "energy": 0.8473,
-                                    "total": 1.1962,
-                                    "tax": 0.3489,
-                                    "difference": -16.689148289604262,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-08T00:00:00.000+01:00",
-                                    "energy": 0.4325,
-                                    "total": 0.6776,
-                                    "tax": 0.2451,
-                                    "difference": -57.474397067454085,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-09T00:00:00.000+01:00",
-                                    "energy": 1.3274,
-                                    "total": 1.7963,
-                                    "tax": 0.4689,
-                                    "difference": 30.51672909285884,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-10T00:00:00.000+01:00",
-                                    "energy": 1.3109,
-                                    "total": 1.7756,
-                                    "tax": 0.4647,
-                                    "difference": 28.894365050345527,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2023-01-11T00:00:00.000+01:00",
-                                    "energy": 0.6358,
-                                    "total": 0.9318,
-                                    "tax": 0.296,
-                                    "difference": -37.484905561820355,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-12T00:00:00.000+01:00",
-                                    "energy": 0.6574,
-                                    "total": 0.9588,
-                                    "tax": 0.3014,
-                                    "difference": -35.36108354253021,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-13T00:00:00.000+01:00",
-                                    "energy": 0.7704,
-                                    "total": 1.1,
-                                    "tax": 0.3296,
-                                    "difference": -24.250347978651163,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-14T00:00:00.000+01:00",
-                                    "energy": 0.6225,
-                                    "total": 0.9151,
-                                    "tax": 0.2926,
-                                    "difference": -38.792629305179574,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-15T00:00:00.000+01:00",
-                                    "energy": 0.2018,
-                                    "total": 0.3893,
-                                    "tax": 0.1875,
-                                    "difference": -80.15799613459475,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-16T00:00:00.000+01:00",
-                                    "energy": 0.897,
-                                    "total": 1.2582,
-                                    "tax": 0.3612,
-                                    "difference": -11.802391143367203,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-17T00:00:00.000+01:00",
-                                    "energy": 0.6994,
-                                    "total": 1.0113,
-                                    "tax": 0.3119,
-                                    "difference": -31.231429616132672,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2023-01-18T00:00:00.000+01:00",
-                                    "energy": 1.0317,
-                                    "total": 1.4266,
-                                    "tax": 0.3949,
-                                    "difference": 1.4419989491505874,
+                                    "difference": 0.8900519518615368,
                                     "level": "NORMAL"
                                 },
                                 {
-                                    "time": "2023-01-19T00:00:00.000+01:00",
-                                    "energy": 1.4935,
-                                    "total": 2.0039,
-                                    "tax": 0.5104,
-                                    "difference": 46.84852712082619,
+                                    "time": "2026-06-07T00:00:00.000+02:00",
+                                    "energy": 0.3558,
+                                    "total": 0.5607,
+                                    "tax": 0.2049,
+                                    "difference": -57.42803547856696,
+                                    "level": "LOW"
+                                },
+                                {
+                                    "time": "2026-06-08T00:00:00.000+02:00",
+                                    "energy": 1.2328,
+                                    "total": 1.657,
+                                    "tax": 0.4242,
+                                    "difference": 47.50623345144081,
                                     "level": "HIGH"
+                                },
+                                {
+                                    "time": "2026-06-09T00:00:00.000+02:00",
+                                    "energy": 1.0104,
+                                    "total": 1.379,
+                                    "tax": 0.3686,
+                                    "difference": 20.895764340798024,
+                                    "level": "HIGH"
+                                },
+                                {
+                                    "time": "2026-06-10T00:00:00.000+02:00",
+                                    "energy": 0.684,
+                                    "total": 0.971,
+                                    "tax": 0.287,
+                                    "difference": -18.158449317987078,
+                                    "level": "LOW"
                                 }
                             ]
                         },
                         "monthly": {
-                            "minEnergy": 0.0926,
-                            "maxEnergy": 2.6902,
-                            "minTotal": 0.1401,
-                            "maxTotal": 3.4721,
+                            "minEnergy": 0.0854,
+                            "maxEnergy": 1.1023,
+                            "minTotal": 0.2068,
+                            "maxTotal": 1.4939,
                             "currency": "SEK",
                             "entries": [
                                 {
-                                    "time": "2020-02-01T00:00:00.000+01:00",
-                                    "energy": 0.1946,
-                                    "total": 0.2682,
-                                    "tax": 0.0736,
-                                    "difference": -74.8091520706506,
+                                    "time": "2023-07-01T00:00:00.000+02:00",
+                                    "energy": 0.3765,
+                                    "total": 0.5768,
+                                    "tax": 0.2003,
+                                    "difference": -28.87615509343074,
                                     "level": "LOW"
                                 },
                                 {
-                                    "time": "2020-03-01T00:00:00.000+01:00",
-                                    "energy": 0.1496,
-                                    "total": 0.2114,
-                                    "tax": 0.0618,
-                                    "difference": -80.63437384259676,
+                                    "time": "2023-08-01T00:00:00.000+02:00",
+                                    "energy": 0.3696,
+                                    "total": 0.5657,
+                                    "tax": 0.1961,
+                                    "difference": -30.179619980164674,
                                     "level": "LOW"
                                 },
                                 {
-                                    "time": "2020-04-01T00:00:00.000+02:00",
-                                    "energy": 0.098,
-                                    "total": 0.1469,
-                                    "tax": 0.0489,
-                                    "difference": -87.31396147442835,
+                                    "time": "2023-09-01T00:00:00.000+02:00",
+                                    "energy": 0.2432,
+                                    "total": 0.4268,
+                                    "tax": 0.1836,
+                                    "difference": -54.057585441493636,
                                     "level": "LOW"
                                 },
                                 {
-                                    "time": "2020-05-01T00:00:00.000+02:00",
-                                    "energy": 0.1354,
-                                    "total": 0.1937,
-                                    "tax": 0.0583,
-                                    "difference": -82.47255493507755,
+                                    "time": "2023-10-01T00:00:00.000+02:00",
+                                    "energy": 0.3306,
+                                    "total": 0.536,
+                                    "tax": 0.2054,
+                                    "difference": -37.547030209530405,
                                     "level": "LOW"
                                 },
                                 {
-                                    "time": "2020-06-01T00:00:00.000+02:00",
-                                    "energy": 0.2489,
-                                    "total": 0.3355,
-                                    "tax": 0.0866,
-                                    "difference": -67.78005113250222,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2020-07-01T00:00:00.000+02:00",
-                                    "energy": 0.0926,
-                                    "total": 0.1401,
-                                    "tax": 0.0475,
-                                    "difference": -88.0129880870619,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2020-08-01T00:00:00.000+02:00",
-                                    "energy": 0.3471,
-                                    "total": 0.4582,
-                                    "tax": 0.1111,
-                                    "difference": -55.0681227323886,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2020-09-01T00:00:00.000+02:00",
-                                    "energy": 0.3485,
-                                    "total": 0.4575,
-                                    "tax": 0.109,
-                                    "difference": -54.886893610594726,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2020-10-01T00:00:00.000+02:00",
-                                    "energy": 0.2302,
-                                    "total": 0.3089,
-                                    "tax": 0.0787,
-                                    "difference": -70.20075440217764,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2020-11-01T00:00:00.000+01:00",
-                                    "energy": 0.2413,
-                                    "total": 0.3215,
-                                    "tax": 0.0802,
-                                    "difference": -68.76386636509758,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2020-12-01T00:00:00.000+01:00",
-                                    "energy": 0.3158,
-                                    "total": 0.4141,
-                                    "tax": 0.0983,
-                                    "difference": -59.11988809820893,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2021-01-01T00:00:00.000+01:00",
-                                    "energy": 0.4905,
-                                    "total": 0.6343,
-                                    "tax": 0.1438,
-                                    "difference": -36.50508268578684,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2021-02-01T00:00:00.000+01:00",
-                                    "energy": 0.5362,
-                                    "total": 0.6914,
-                                    "tax": 0.1552,
-                                    "difference": -30.589246352943732,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2021-03-01T00:00:00.000+01:00",
-                                    "energy": 0.3678,
-                                    "total": 0.4804,
-                                    "tax": 0.1126,
-                                    "difference": -52.38852071729337,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2021-04-01T00:00:00.000+02:00",
-                                    "energy": 0.3368,
-                                    "total": 0.4416,
-                                    "tax": 0.1048,
-                                    "difference": -56.40145127130073,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2021-05-01T00:00:00.000+02:00",
-                                    "energy": 0.435,
-                                    "total": 0.5653,
-                                    "tax": 0.1303,
-                                    "difference": -43.6895228711871,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2021-06-01T00:00:00.000+02:00",
-                                    "energy": 0.403,
-                                    "total": 0.5273,
-                                    "tax": 0.1243,
-                                    "difference": -47.83190279790437,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2021-07-01T00:00:00.000+02:00",
-                                    "energy": 0.5905,
-                                    "total": 0.761,
-                                    "tax": 0.1705,
-                                    "difference": -23.560145414795358,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2021-08-01T00:00:00.000+02:00",
-                                    "energy": 0.6711,
-                                    "total": 0.8627,
-                                    "tax": 0.1916,
-                                    "difference": -13.126525974376236,
-                                    "level": "LOW"
-                                },
-                                {
-                                    "time": "2021-09-01T00:00:00.000+02:00",
-                                    "energy": 0.9184,
-                                    "total": 1.1724,
-                                    "tax": 0.254,
-                                    "difference": 18.886303896785677,
+                                    "time": "2023-11-01T00:00:00.000+01:00",
+                                    "energy": 0.8213,
+                                    "total": 1.1489,
+                                    "tax": 0.3276,
+                                    "difference": 55.150103112258535,
                                     "level": "HIGH"
                                 },
                                 {
-                                    "time": "2021-10-01T00:00:00.000+02:00",
-                                    "energy": 0.6475,
-                                    "total": 0.8404,
-                                    "tax": 0.1929,
-                                    "difference": -16.18153117033023,
-                                    "level": "LOW"
+                                    "time": "2023-12-01T00:00:00.000+01:00",
+                                    "energy": 0.7917,
+                                    "total": 1.1117,
+                                    "tax": 0.32,
+                                    "difference": 49.558427656124536,
+                                    "level": "HIGH"
                                 },
                                 {
-                                    "time": "2021-11-01T00:00:00.000+01:00",
-                                    "energy": 0.8352,
-                                    "total": 1.0696,
-                                    "tax": 0.2344,
-                                    "difference": 8.116116087320762,
+                                    "time": "2024-01-01T00:00:00.000+01:00",
+                                    "energy": 0.803,
+                                    "total": 1.1212,
+                                    "tax": 0.3182,
+                                    "difference": 51.693087543094634,
+                                    "level": "HIGH"
+                                },
+                                {
+                                    "time": "2024-02-01T00:00:00.000+01:00",
+                                    "energy": 0.5034,
+                                    "total": 0.7468,
+                                    "tax": 0.2434,
+                                    "difference": -4.903735654802205,
                                     "level": "NORMAL"
                                 },
                                 {
-                                    "time": "2021-12-01T00:00:00.000+01:00",
-                                    "energy": 1.8074,
-                                    "total": 2.2849,
-                                    "tax": 0.4775,
-                                    "difference": 133.96679623589984,
+                                    "time": "2024-03-01T00:00:00.000+01:00",
+                                    "energy": 0.5947,
+                                    "total": 0.8485,
+                                    "tax": 0.2538,
+                                    "difference": 12.343560600097604,
                                     "level": "HIGH"
                                 },
                                 {
-                                    "time": "2022-01-01T00:00:00.000+01:00",
-                                    "energy": 1.0433,
-                                    "total": 1.3353,
-                                    "tax": 0.292,
-                                    "difference": 35.05453054825401,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2022-02-01T00:00:00.000+01:00",
-                                    "energy": 0.7748,
-                                    "total": 1.0075,
-                                    "tax": 0.2327,
-                                    "difference": 0.2973739756419178,
+                                    "time": "2024-04-01T00:00:00.000+02:00",
+                                    "energy": 0.5631,
+                                    "total": 0.8052,
+                                    "tax": 0.2421,
+                                    "difference": 6.374069234765358,
                                     "level": "NORMAL"
                                 },
                                 {
-                                    "time": "2022-03-01T00:00:00.000+01:00",
-                                    "energy": 1.3033,
-                                    "total": 1.6692,
-                                    "tax": 0.3659,
-                                    "difference": 68.71136745283181,
+                                    "time": "2024-05-01T00:00:00.000+02:00",
+                                    "energy": 0.2371,
+                                    "total": 0.3964,
+                                    "tax": 0.1593,
+                                    "difference": -55.209923964548274,
+                                    "level": "LOW"
+                                },
+                                {
+                                    "time": "2024-06-01T00:00:00.000+02:00",
+                                    "energy": 0.2727,
+                                    "total": 0.4408,
+                                    "tax": 0.1681,
+                                    "difference": -48.48480078081955,
+                                    "level": "LOW"
+                                },
+                                {
+                                    "time": "2024-07-01T00:00:00.000+02:00",
+                                    "energy": 0.2072,
+                                    "total": 0.359,
+                                    "tax": 0.1518,
+                                    "difference": -60.85827180706202,
+                                    "level": "LOW"
+                                },
+                                {
+                                    "time": "2024-08-01T00:00:00.000+02:00",
+                                    "energy": 0.0854,
+                                    "total": 0.2068,
+                                    "tax": 0.1214,
+                                    "difference": -83.86726067723501,
+                                    "level": "LOW"
+                                },
+                                {
+                                    "time": "2024-09-01T00:00:00.000+02:00",
+                                    "energy": 0.1644,
+                                    "total": 0.3055,
+                                    "tax": 0.1411,
+                                    "difference": -68.94353226390442,
+                                    "level": "LOW"
+                                },
+                                {
+                                    "time": "2024-10-01T00:00:00.000+02:00",
+                                    "energy": 0.2297,
+                                    "total": 0.3821,
+                                    "tax": 0.1524,
+                                    "difference": -56.60784282858178,
+                                    "level": "LOW"
+                                },
+                                {
+                                    "time": "2024-11-01T00:00:00.000+01:00",
+                                    "energy": 0.6695,
+                                    "total": 0.9231,
+                                    "tax": 0.2536,
+                                    "difference": 26.473875604111868,
                                     "level": "HIGH"
                                 },
                                 {
-                                    "time": "2022-04-01T00:00:00.000+02:00",
-                                    "energy": 0.8922,
-                                    "total": 1.1576,
-                                    "tax": 0.2654,
-                                    "difference": 15.494730331785902,
+                                    "time": "2024-12-01T00:00:00.000+01:00",
+                                    "energy": 0.5825,
+                                    "total": 0.8144,
+                                    "tax": 0.2319,
+                                    "difference": 10.038883553988313,
                                     "level": "HIGH"
                                 },
                                 {
-                                    "time": "2022-05-01T00:00:00.000+02:00",
-                                    "energy": 1.0286,
-                                    "total": 1.3264,
-                                    "tax": 0.2978,
-                                    "difference": 33.15162476941828,
+                                    "time": "2025-01-01T00:00:00.000+01:00",
+                                    "energy": 0.6344,
+                                    "total": 0.8793,
+                                    "tax": 0.2449,
+                                    "difference": 19.843206397682707,
                                     "level": "HIGH"
                                 },
                                 {
-                                    "time": "2022-06-01T00:00:00.000+02:00",
-                                    "energy": 1.2631,
-                                    "total": 1.6191,
-                                    "tax": 0.356,
-                                    "difference": 63.507502669893256,
+                                    "time": "2025-02-01T00:00:00.000+01:00",
+                                    "energy": 0.7705,
+                                    "total": 1.0494,
+                                    "tax": 0.2789,
+                                    "difference": 45.55357901862317,
                                     "level": "HIGH"
                                 },
                                 {
-                                    "time": "2022-07-01T00:00:00.000+02:00",
-                                    "energy": 0.8661,
-                                    "total": 1.1275,
-                                    "tax": 0.2614,
-                                    "difference": 12.11610170405713,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2022-08-01T00:00:00.000+02:00",
-                                    "energy": 2.2305,
-                                    "total": 2.8397,
-                                    "tax": 0.6092,
-                                    "difference": 188.7368258294648,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2022-09-01T00:00:00.000+02:00",
-                                    "energy": 2.2863,
-                                    "total": 2.9324,
-                                    "tax": 0.6461,
-                                    "difference": 195.96010082667806,
-                                    "level": "HIGH"
-                                },
-                                {
-                                    "time": "2022-10-01T00:00:00.000+02:00",
-                                    "energy": 0.8065,
-                                    "total": 1.1039,
-                                    "tax": 0.2974,
-                                    "difference": 4.4009190905462106,
+                                    "time": "2025-03-01T00:00:00.000+01:00",
+                                    "energy": 0.5081,
+                                    "total": 0.7214,
+                                    "tax": 0.2133,
+                                    "difference": -4.015868268186338,
                                     "level": "NORMAL"
                                 },
                                 {
-                                    "time": "2022-11-01T00:00:00.000+01:00",
-                                    "energy": 1.3088,
-                                    "total": 1.7438,
-                                    "tax": 0.435,
-                                    "difference": 69.42333900273636,
+                                    "time": "2025-04-01T00:00:00.000+02:00",
+                                    "energy": 0.3761,
+                                    "total": 0.5561,
+                                    "tax": 0.18,
+                                    "difference": -28.95171827527038,
+                                    "level": "LOW"
+                                },
+                                {
+                                    "time": "2025-05-01T00:00:00.000+02:00",
+                                    "energy": 0.4294,
+                                    "total": 0.6228,
+                                    "tax": 0.1934,
+                                    "difference": -18.8829242951372,
+                                    "level": "LOW"
+                                },
+                                {
+                                    "time": "2025-06-01T00:00:00.000+02:00",
+                                    "energy": 0.2278,
+                                    "total": 0.3708,
+                                    "tax": 0.143,
+                                    "difference": -56.966767942320104,
+                                    "level": "LOW"
+                                },
+                                {
+                                    "time": "2025-07-01T00:00:00.000+02:00",
+                                    "energy": 0.3701,
+                                    "total": 0.5487,
+                                    "tax": 0.1786,
+                                    "difference": -30.085166002865122,
+                                    "level": "LOW"
+                                },
+                                {
+                                    "time": "2025-08-01T00:00:00.000+02:00",
+                                    "energy": 0.4856,
+                                    "total": 0.693,
+                                    "tax": 0.2074,
+                                    "difference": -8.266297246666582,
+                                    "level": "NORMAL"
+                                },
+                                {
+                                    "time": "2025-09-01T00:00:00.000+02:00",
+                                    "energy": 0.5233,
+                                    "total": 0.7401,
+                                    "tax": 0.2168,
+                                    "difference": -1.1444673582796838,
+                                    "level": "NORMAL"
+                                },
+                                {
+                                    "time": "2025-10-01T00:00:00.000+02:00",
+                                    "energy": 0.6281,
+                                    "total": 0.8711,
+                                    "tax": 0.243,
+                                    "difference": 18.653086283708248,
                                     "level": "HIGH"
                                 },
                                 {
-                                    "time": "2022-12-01T00:00:00.000+01:00",
-                                    "energy": 2.6902,
-                                    "total": 3.4721,
-                                    "tax": 0.7819,
-                                    "difference": 248.24470246421254,
+                                    "time": "2025-11-01T00:00:00.000+01:00",
+                                    "energy": 0.6964,
+                                    "total": 0.9566,
+                                    "tax": 0.2602,
+                                    "difference": 31.555499582828247,
                                     "level": "HIGH"
                                 },
                                 {
-                                    "time": "2023-01-01T00:00:00.000+01:00",
-                                    "energy": 0.875,
-                                    "total": 1.2307,
-                                    "tax": 0.3557,
-                                    "difference": 13.268201121175366,
+                                    "time": "2025-12-01T00:00:00.000+01:00",
+                                    "energy": 0.5168,
+                                    "total": 0.732,
+                                    "tax": 0.2152,
+                                    "difference": -2.372369063173977,
+                                    "level": "NORMAL"
+                                },
+                                {
+                                    "time": "2026-01-01T00:00:00.000+01:00",
+                                    "energy": 1.0845,
+                                    "total": 1.4716,
+                                    "tax": 0.3871,
+                                    "difference": 104.87067676274734,
+                                    "level": "HIGH"
+                                },
+                                {
+                                    "time": "2026-02-01T00:00:00.000+01:00",
+                                    "energy": 1.1023,
+                                    "total": 1.4939,
+                                    "tax": 0.3916,
+                                    "difference": 108.23323835461173,
+                                    "level": "HIGH"
+                                },
+                                {
+                                    "time": "2026-03-01T00:00:00.000+01:00",
+                                    "energy": 0.5866,
+                                    "total": 0.8493,
+                                    "tax": 0.2627,
+                                    "difference": 10.813406167844718,
+                                    "level": "HIGH"
+                                },
+                                {
+                                    "time": "2026-04-01T00:00:00.000+02:00",
+                                    "energy": 0.5608,
+                                    "total": 0.817,
+                                    "tax": 0.2562,
+                                    "difference": 5.9395809391873655,
+                                    "level": "NORMAL"
+                                },
+                                {
+                                    "time": "2026-05-01T00:00:00.000+02:00",
+                                    "energy": 0.7705,
+                                    "total": 1.0791,
+                                    "tax": 0.3086,
+                                    "difference": 45.55357901862317,
+                                    "level": "HIGH"
+                                },
+                                {
+                                    "time": "2026-06-01T00:00:00.000+02:00",
+                                    "energy": 0.94,
+                                    "total": 1.2909,
+                                    "tax": 0.3509,
+                                    "difference": 77.57347732317425,
                                     "level": "HIGH"
                                 }
                             ]
@@ -2801,203 +1447,203 @@
                         "status": "running",
                         "priceInfo": {
                             "current": {
-                                "total": 2.2385,
-                                "energy": 1.6812,
-                                "tax": 0.5573,
-                                "startsAt": "2023-01-18T17:00:00.000+01:00",
+                                "total": 1.0832,
+                                "energy": 0.7738,
+                                "tax": 0.3094,
+                                "startsAt": "2026-06-10T00:00:00.000+02:00",
                                 "currency": "SEK",
-                                "level": "VERY_EXPENSIVE"
+                                "level": "NORMAL"
                             },
                             "today": [
                                 {
-                                    "total": 0.6995,
-                                    "energy": 0.45,
-                                    "tax": 0.2495,
-                                    "startsAt": "2023-01-18T00:00:00.000+01:00",
+                                    "total": 1.0832,
+                                    "energy": 0.7738,
+                                    "tax": 0.3094,
+                                    "startsAt": "2026-06-10T00:00:00.000+02:00",
                                     "currency": "SEK",
-                                    "level": "CHEAP"
+                                    "level": "NORMAL"
                                 },
                                 {
-                                    "total": 0.6838,
-                                    "energy": 0.4375,
-                                    "tax": 0.2463,
-                                    "startsAt": "2023-01-18T01:00:00.000+01:00",
-                                    "currency": "SEK",
-                                    "level": "CHEAP"
-                                },
-                                {
-                                    "total": 0.6831,
-                                    "energy": 0.4369,
-                                    "tax": 0.2462,
-                                    "startsAt": "2023-01-18T02:00:00.000+01:00",
-                                    "currency": "SEK",
-                                    "level": "CHEAP"
-                                },
-                                {
-                                    "total": 0.6779,
-                                    "energy": 0.4327,
-                                    "tax": 0.2452,
-                                    "startsAt": "2023-01-18T03:00:00.000+01:00",
-                                    "currency": "SEK",
-                                    "level": "CHEAP"
-                                },
-                                {
-                                    "total": 0.7397,
-                                    "energy": 0.4822,
-                                    "tax": 0.2575,
-                                    "startsAt": "2023-01-18T04:00:00.000+01:00",
-                                    "currency": "SEK",
-                                    "level": "CHEAP"
-                                },
-                                {
-                                    "total": 0.872,
-                                    "energy": 0.588,
+                                    "total": 0.9559,
+                                    "energy": 0.6719,
                                     "tax": 0.284,
-                                    "startsAt": "2023-01-18T05:00:00.000+01:00",
+                                    "startsAt": "2026-06-10T01:00:00.000+02:00",
+                                    "currency": "SEK",
+                                    "level": "CHEAP"
+                                },
+                                {
+                                    "total": 1.1081,
+                                    "energy": 0.7937,
+                                    "tax": 0.3144,
+                                    "startsAt": "2026-06-10T02:00:00.000+02:00",
                                     "currency": "SEK",
                                     "level": "NORMAL"
                                 },
                                 {
-                                    "total": 1.0799,
-                                    "energy": 0.7543,
-                                    "tax": 0.3256,
-                                    "startsAt": "2023-01-18T06:00:00.000+01:00",
+                                    "total": 1.006,
+                                    "energy": 0.712,
+                                    "tax": 0.294,
+                                    "startsAt": "2026-06-10T03:00:00.000+02:00",
                                     "currency": "SEK",
-                                    "level": "EXPENSIVE"
+                                    "level": "CHEAP"
                                 },
                                 {
-                                    "total": 1.2658,
-                                    "energy": 0.9031,
-                                    "tax": 0.3627,
-                                    "startsAt": "2023-01-18T07:00:00.000+01:00",
+                                    "total": 0.9371,
+                                    "energy": 0.6569,
+                                    "tax": 0.2802,
+                                    "startsAt": "2026-06-10T04:00:00.000+02:00",
                                     "currency": "SEK",
-                                    "level": "EXPENSIVE"
+                                    "level": "CHEAP"
                                 },
                                 {
-                                    "total": 1.3024,
-                                    "energy": 0.9323,
-                                    "tax": 0.3701,
-                                    "startsAt": "2023-01-18T08:00:00.000+01:00",
+                                    "total": 0.89,
+                                    "energy": 0.6192,
+                                    "tax": 0.2708,
+                                    "startsAt": "2026-06-10T05:00:00.000+02:00",
                                     "currency": "SEK",
-                                    "level": "EXPENSIVE"
+                                    "level": "CHEAP"
                                 },
                                 {
-                                    "total": 1.3017,
-                                    "energy": 0.9317,
-                                    "tax": 0.37,
-                                    "startsAt": "2023-01-18T09:00:00.000+01:00",
-                                    "currency": "SEK",
-                                    "level": "EXPENSIVE"
-                                },
-                                {
-                                    "total": 1.4063,
-                                    "energy": 1.0154,
-                                    "tax": 0.3909,
-                                    "startsAt": "2023-01-18T10:00:00.000+01:00",
-                                    "currency": "SEK",
-                                    "level": "VERY_EXPENSIVE"
-                                },
-                                {
-                                    "total": 1.5337,
-                                    "energy": 1.1174,
-                                    "tax": 0.4163,
-                                    "startsAt": "2023-01-18T11:00:00.000+01:00",
-                                    "currency": "SEK",
-                                    "level": "VERY_EXPENSIVE"
-                                },
-                                {
-                                    "total": 1.6887,
-                                    "energy": 1.2414,
-                                    "tax": 0.4473,
-                                    "startsAt": "2023-01-18T12:00:00.000+01:00",
-                                    "currency": "SEK",
-                                    "level": "VERY_EXPENSIVE"
-                                },
-                                {
-                                    "total": 1.8244,
-                                    "energy": 1.3499,
-                                    "tax": 0.4745,
-                                    "startsAt": "2023-01-18T13:00:00.000+01:00",
-                                    "currency": "SEK",
-                                    "level": "VERY_EXPENSIVE"
-                                },
-                                {
-                                    "total": 1.8825,
-                                    "energy": 1.3964,
-                                    "tax": 0.4861,
-                                    "startsAt": "2023-01-18T14:00:00.000+01:00",
-                                    "currency": "SEK",
-                                    "level": "VERY_EXPENSIVE"
-                                },
-                                {
-                                    "total": 2.0116,
-                                    "energy": 1.4996,
-                                    "tax": 0.512,
-                                    "startsAt": "2023-01-18T15:00:00.000+01:00",
-                                    "currency": "SEK",
-                                    "level": "VERY_EXPENSIVE"
-                                },
-                                {
-                                    "total": 2.1588,
-                                    "energy": 1.6174,
-                                    "tax": 0.5414,
-                                    "startsAt": "2023-01-18T16:00:00.000+01:00",
-                                    "currency": "SEK",
-                                    "level": "VERY_EXPENSIVE"
-                                },
-                                {
-                                    "total": 2.2385,
-                                    "energy": 1.6812,
-                                    "tax": 0.5573,
-                                    "startsAt": "2023-01-18T17:00:00.000+01:00",
-                                    "currency": "SEK",
-                                    "level": "VERY_EXPENSIVE"
-                                },
-                                {
-                                    "total": 2.0776,
-                                    "energy": 1.5525,
-                                    "tax": 0.5251,
-                                    "startsAt": "2023-01-18T18:00:00.000+01:00",
-                                    "currency": "SEK",
-                                    "level": "VERY_EXPENSIVE"
-                                },
-                                {
-                                    "total": 1.9317,
-                                    "energy": 1.4357,
-                                    "tax": 0.496,
-                                    "startsAt": "2023-01-18T19:00:00.000+01:00",
-                                    "currency": "SEK",
-                                    "level": "VERY_EXPENSIVE"
-                                },
-                                {
-                                    "total": 1.8446,
-                                    "energy": 1.366,
-                                    "tax": 0.4786,
-                                    "startsAt": "2023-01-18T20:00:00.000+01:00",
-                                    "currency": "SEK",
-                                    "level": "VERY_EXPENSIVE"
-                                },
-                                {
-                                    "total": 1.8295,
-                                    "energy": 1.354,
-                                    "tax": 0.4755,
-                                    "startsAt": "2023-01-18T21:00:00.000+01:00",
-                                    "currency": "SEK",
-                                    "level": "VERY_EXPENSIVE"
-                                },
-                                {
-                                    "total": 1.2986,
-                                    "energy": 0.9293,
-                                    "tax": 0.3693,
-                                    "startsAt": "2023-01-18T22:00:00.000+01:00",
+                                    "total": 1.1478,
+                                    "energy": 0.8254,
+                                    "tax": 0.3224,
+                                    "startsAt": "2026-06-10T06:00:00.000+02:00",
                                     "currency": "SEK",
                                     "level": "NORMAL"
                                 },
                                 {
-                                    "total": 1.2065,
-                                    "energy": 0.8556,
-                                    "tax": 0.3509,
-                                    "startsAt": "2023-01-18T23:00:00.000+01:00",
+                                    "total": 1.3209,
+                                    "energy": 0.9639,
+                                    "tax": 0.357,
+                                    "startsAt": "2026-06-10T07:00:00.000+02:00",
+                                    "currency": "SEK",
+                                    "level": "NORMAL"
+                                },
+                                {
+                                    "total": 1.1413,
+                                    "energy": 0.8202,
+                                    "tax": 0.3211,
+                                    "startsAt": "2026-06-10T08:00:00.000+02:00",
+                                    "currency": "SEK",
+                                    "level": "NORMAL"
+                                },
+                                {
+                                    "total": 0.779,
+                                    "energy": 0.5304,
+                                    "tax": 0.2486,
+                                    "startsAt": "2026-06-10T09:00:00.000+02:00",
+                                    "currency": "SEK",
+                                    "level": "CHEAP"
+                                },
+                                {
+                                    "total": 0.6469,
+                                    "energy": 0.4247,
+                                    "tax": 0.2222,
+                                    "startsAt": "2026-06-10T10:00:00.000+02:00",
+                                    "currency": "SEK",
+                                    "level": "VERY_CHEAP"
+                                },
+                                {
+                                    "total": 0.478,
+                                    "energy": 0.2895,
+                                    "tax": 0.1885,
+                                    "startsAt": "2026-06-10T11:00:00.000+02:00",
+                                    "currency": "SEK",
+                                    "level": "VERY_CHEAP"
+                                },
+                                {
+                                    "total": 0.372,
+                                    "energy": 0.2048,
+                                    "tax": 0.1672,
+                                    "startsAt": "2026-06-10T12:00:00.000+02:00",
+                                    "currency": "SEK",
+                                    "level": "VERY_CHEAP"
+                                },
+                                {
+                                    "total": 0.3001,
+                                    "energy": 0.1473,
+                                    "tax": 0.1528,
+                                    "startsAt": "2026-06-10T13:00:00.000+02:00",
+                                    "currency": "SEK",
+                                    "level": "VERY_CHEAP"
+                                },
+                                {
+                                    "total": 0.2516,
+                                    "energy": 0.1085,
+                                    "tax": 0.1431,
+                                    "startsAt": "2026-06-10T14:00:00.000+02:00",
+                                    "currency": "SEK",
+                                    "level": "VERY_CHEAP"
+                                },
+                                {
+                                    "total": 0.5078,
+                                    "energy": 0.3134,
+                                    "tax": 0.1944,
+                                    "startsAt": "2026-06-10T15:00:00.000+02:00",
+                                    "currency": "SEK",
+                                    "level": "VERY_CHEAP"
+                                },
+                                {
+                                    "total": 0.8294,
+                                    "energy": 0.5707,
+                                    "tax": 0.2587,
+                                    "startsAt": "2026-06-10T16:00:00.000+02:00",
+                                    "currency": "SEK",
+                                    "level": "CHEAP"
+                                },
+                                {
+                                    "total": 1.0328,
+                                    "energy": 0.7334,
+                                    "tax": 0.2994,
+                                    "startsAt": "2026-06-10T17:00:00.000+02:00",
+                                    "currency": "SEK",
+                                    "level": "CHEAP"
+                                },
+                                {
+                                    "total": 1.2246,
+                                    "energy": 0.8869,
+                                    "tax": 0.3377,
+                                    "startsAt": "2026-06-10T18:00:00.000+02:00",
+                                    "currency": "SEK",
+                                    "level": "NORMAL"
+                                },
+                                {
+                                    "total": 1.4324,
+                                    "energy": 1.0531,
+                                    "tax": 0.3793,
+                                    "startsAt": "2026-06-10T19:00:00.000+02:00",
+                                    "currency": "SEK",
+                                    "level": "NORMAL"
+                                },
+                                {
+                                    "total": 1.6137,
+                                    "energy": 1.1981,
+                                    "tax": 0.4156,
+                                    "startsAt": "2026-06-10T20:00:00.000+02:00",
+                                    "currency": "SEK",
+                                    "level": "EXPENSIVE"
+                                },
+                                {
+                                    "total": 1.5628,
+                                    "energy": 1.1574,
+                                    "tax": 0.4054,
+                                    "startsAt": "2026-06-10T21:00:00.000+02:00",
+                                    "currency": "SEK",
+                                    "level": "EXPENSIVE"
+                                },
+                                {
+                                    "total": 1.4174,
+                                    "energy": 1.0412,
+                                    "tax": 0.3762,
+                                    "startsAt": "2026-06-10T22:00:00.000+02:00",
+                                    "currency": "SEK",
+                                    "level": "NORMAL"
+                                },
+                                {
+                                    "total": 1.2653,
+                                    "energy": 0.9194,
+                                    "tax": 0.3459,
+                                    "startsAt": "2026-06-10T23:00:00.000+02:00",
                                     "currency": "SEK",
                                     "level": "NORMAL"
                                 }
@@ -3010,2300 +1656,1140 @@
                                 "low": -10
                             },
                             "hourly": {
-                                "minEnergy": 0.0011,
-                                "maxEnergy": 2.0141,
-                                "minTotal": 0.1384,
-                                "maxTotal": 2.6547,
+                                "minEnergy": 0.1085,
+                                "maxEnergy": 2.0519,
+                                "minTotal": 0.2516,
+                                "maxTotal": 2.6808,
                                 "currency": "SEK",
                                 "entries": [
                                     {
-                                        "time": "2023-01-11T00:00:00.000+01:00",
-                                        "energy": 0.4702,
-                                        "total": 0.7248,
-                                        "tax": 0.2546,
-                                        "difference": -39.62886833254673,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-11T01:00:00.000+01:00",
-                                        "energy": 0.3102,
-                                        "total": 0.5248,
-                                        "tax": 0.2146,
-                                        "difference": -60.17200118408336,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-11T02:00:00.000+01:00",
-                                        "energy": 0.2816,
-                                        "total": 0.489,
-                                        "tax": 0.2074,
-                                        "difference": -63.84408618129553,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-11T03:00:00.000+01:00",
-                                        "energy": 0.2525,
-                                        "total": 0.4526,
-                                        "tax": 0.2001,
-                                        "difference": -67.58036846866875,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-11T04:00:00.000+01:00",
-                                        "energy": 0.2852,
-                                        "total": 0.4935,
-                                        "tax": 0.2083,
-                                        "difference": -63.38186569213596,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-11T05:00:00.000+01:00",
-                                        "energy": 0.2976,
-                                        "total": 0.509,
-                                        "tax": 0.2114,
-                                        "difference": -61.78977289614187,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-11T06:00:00.000+01:00",
-                                        "energy": 0.5431,
-                                        "total": 0.8158,
-                                        "tax": 0.2727,
-                                        "difference": -30.268903427065354,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-11T07:00:00.000+01:00",
-                                        "energy": 0.7999,
-                                        "total": 1.1368,
-                                        "tax": 0.3369,
-                                        "difference": 2.7028247996509407,
+                                        "time": "2026-06-08T00:00:00.000+02:00",
+                                        "energy": 0.9424,
+                                        "total": 1.294,
+                                        "tax": 0.3516,
+                                        "difference": -3.4152715719529994,
                                         "level": "NORMAL"
                                     },
                                     {
-                                        "time": "2023-01-11T08:00:00.000+01:00",
-                                        "energy": 0.8135,
-                                        "total": 1.1539,
-                                        "tax": 0.3404,
-                                        "difference": 4.448991092031534,
+                                        "time": "2026-06-08T01:00:00.000+02:00",
+                                        "energy": 0.9321,
+                                        "total": 1.2812,
+                                        "tax": 0.3491,
+                                        "difference": -4.470898378838484,
                                         "level": "NORMAL"
                                     },
                                     {
-                                        "time": "2023-01-11T09:00:00.000+01:00",
-                                        "energy": 0.7827,
-                                        "total": 1.1154,
-                                        "tax": 0.3327,
-                                        "difference": 0.49443801811075616,
+                                        "time": "2026-06-08T02:00:00.000+02:00",
+                                        "energy": 0.9208,
+                                        "total": 1.267,
+                                        "tax": 0.3462,
+                                        "difference": -5.629013225227425,
                                         "level": "NORMAL"
                                     },
                                     {
-                                        "time": "2023-01-11T10:00:00.000+01:00",
-                                        "energy": 0.7708,
-                                        "total": 1.1005,
-                                        "tax": 0.3297,
-                                        "difference": -1.0334574877222735,
+                                        "time": "2026-06-08T03:00:00.000+02:00",
+                                        "energy": 0.9086,
+                                        "total": 1.2517,
+                                        "tax": 0.3431,
+                                        "difference": -6.87936730716946,
                                         "level": "NORMAL"
                                     },
                                     {
-                                        "time": "2023-01-11T11:00:00.000+01:00",
-                                        "energy": 0.7752,
-                                        "total": 1.106,
-                                        "tax": 0.3308,
-                                        "difference": -0.46852133430502363,
+                                        "time": "2026-06-08T04:00:00.000+02:00",
+                                        "energy": 0.9369,
+                                        "total": 1.2871,
+                                        "tax": 0.3502,
+                                        "difference": -3.9789557892219563,
                                         "level": "NORMAL"
                                     },
                                     {
-                                        "time": "2023-01-11T12:00:00.000+01:00",
-                                        "energy": 0.7704,
-                                        "total": 1.1,
-                                        "tax": 0.3296,
-                                        "difference": -1.0848153198511312,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2023-01-11T13:00:00.000+01:00",
-                                        "energy": 0.7474,
-                                        "total": 1.0712,
-                                        "tax": 0.3238,
-                                        "difference": -4.037890667259518,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2023-01-11T14:00:00.000+01:00",
-                                        "energy": 0.7778,
-                                        "total": 1.1093,
-                                        "tax": 0.3315,
-                                        "difference": -0.1346954254675552,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2023-01-11T15:00:00.000+01:00",
-                                        "energy": 0.8493,
-                                        "total": 1.1986,
-                                        "tax": 0.3493,
-                                        "difference": 9.04551706756287,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2023-01-11T16:00:00.000+01:00",
-                                        "energy": 0.8597,
-                                        "total": 1.2116,
-                                        "tax": 0.3519,
-                                        "difference": 10.380820702912757,
+                                        "time": "2026-06-08T05:00:00.000+02:00",
+                                        "energy": 1.0905,
+                                        "total": 1.4791,
+                                        "tax": 0.3886,
+                                        "difference": 11.763207078507264,
                                         "level": "HIGH"
                                     },
                                     {
-                                        "time": "2023-01-11T17:00:00.000+01:00",
-                                        "energy": 0.8288,
-                                        "total": 1.173,
-                                        "tax": 0.3442,
-                                        "difference": 6.413428170959733,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2023-01-11T18:00:00.000+01:00",
-                                        "energy": 0.84,
-                                        "total": 1.187,
-                                        "tax": 0.347,
-                                        "difference": 7.851447470567294,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2023-01-11T19:00:00.000+01:00",
-                                        "energy": 0.7607,
-                                        "total": 1.0879,
-                                        "tax": 0.3272,
-                                        "difference": -2.330242748975536,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2023-01-11T20:00:00.000+01:00",
-                                        "energy": 0.729,
-                                        "total": 1.0483,
-                                        "tax": 0.3193,
-                                        "difference": -6.400350945186233,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2023-01-11T21:00:00.000+01:00",
-                                        "energy": 0.6714,
-                                        "total": 0.9763,
-                                        "tax": 0.3049,
-                                        "difference": -13.795878771739424,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-11T22:00:00.000+01:00",
-                                        "energy": 0.5584,
-                                        "total": 0.835,
-                                        "tax": 0.2766,
-                                        "difference": -28.304466348137154,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-11T23:00:00.000+01:00",
-                                        "energy": 0.4847,
-                                        "total": 0.7428,
-                                        "tax": 0.2581,
-                                        "difference": -37.76714691787622,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-12T00:00:00.000+01:00",
-                                        "energy": 0.2239,
-                                        "total": 0.4169,
-                                        "tax": 0.193,
-                                        "difference": -71.25245346588093,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-12T01:00:00.000+01:00",
-                                        "energy": 0.0625,
-                                        "total": 0.2152,
-                                        "tax": 0.1527,
-                                        "difference": -91.9753387298685,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-12T02:00:00.000+01:00",
-                                        "energy": 0.0528,
-                                        "total": 0.203,
-                                        "tax": 0.1502,
-                                        "difference": -93.22076615899292,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-12T03:00:00.000+01:00",
-                                        "energy": 0.0011,
-                                        "total": 0.1384,
-                                        "tax": 0.1373,
-                                        "difference": -99.85876596164569,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-12T04:00:00.000+01:00",
-                                        "energy": 0.0308,
-                                        "total": 0.1754,
-                                        "tax": 0.1446,
-                                        "difference": -96.0454469260792,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-12T05:00:00.000+01:00",
-                                        "energy": 0.2809,
-                                        "total": 0.4882,
-                                        "tax": 0.2073,
-                                        "difference": -63.93396238752101,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-12T06:00:00.000+01:00",
-                                        "energy": 0.4056,
-                                        "total": 0.644,
-                                        "tax": 0.2384,
-                                        "difference": -47.92315822135465,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-12T07:00:00.000+01:00",
-                                        "energy": 0.6756,
-                                        "total": 0.9816,
-                                        "tax": 0.306,
-                                        "difference": -13.256621534386582,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-12T08:00:00.000+01:00",
-                                        "energy": 0.7342,
-                                        "total": 1.0548,
-                                        "tax": 0.3206,
-                                        "difference": -5.732699127511296,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2023-01-12T09:00:00.000+01:00",
-                                        "energy": 0.7325,
-                                        "total": 1.0527,
-                                        "tax": 0.3202,
-                                        "difference": -5.950969914058874,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2023-01-12T10:00:00.000+01:00",
-                                        "energy": 0.7468,
-                                        "total": 1.0706,
-                                        "tax": 0.3238,
-                                        "difference": -4.114927415452769,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2023-01-12T11:00:00.000+01:00",
-                                        "energy": 0.7516,
-                                        "total": 1.0765,
-                                        "tax": 0.3249,
-                                        "difference": -3.4986334299066755,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2023-01-12T12:00:00.000+01:00",
-                                        "energy": 0.7502,
-                                        "total": 1.0748,
-                                        "tax": 0.3246,
-                                        "difference": -3.6783858423576277,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2023-01-12T13:00:00.000+01:00",
-                                        "energy": 0.7981,
-                                        "total": 1.1346,
-                                        "tax": 0.3365,
-                                        "difference": 2.4717145550711592,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2023-01-12T14:00:00.000+01:00",
-                                        "energy": 0.8309,
-                                        "total": 1.1756,
-                                        "tax": 0.3447,
-                                        "difference": 6.683056789636169,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2023-01-12T15:00:00.000+01:00",
-                                        "energy": 1.0464,
-                                        "total": 1.445,
-                                        "tax": 0.3986,
-                                        "difference": 34.35208884904958,
+                                        "time": "2026-06-08T06:00:00.000+02:00",
+                                        "energy": 1.2802,
+                                        "total": 1.7163,
+                                        "tax": 0.4361,
+                                        "difference": 31.20518817231087,
                                         "level": "HIGH"
                                     },
                                     {
-                                        "time": "2023-01-12T16:00:00.000+01:00",
-                                        "energy": 1.0893,
-                                        "total": 1.4986,
-                                        "tax": 0.4093,
-                                        "difference": 39.86021634486781,
+                                        "time": "2026-06-08T07:00:00.000+02:00",
+                                        "energy": 1.5269,
+                                        "total": 2.0246,
+                                        "tax": 0.4977,
+                                        "difference": 56.48898751781087,
                                         "level": "HIGH"
                                     },
                                     {
-                                        "time": "2023-01-12T17:00:00.000+01:00",
-                                        "energy": 1.2384,
-                                        "total": 1.685,
-                                        "tax": 0.4466,
-                                        "difference": 59.00384827089351,
+                                        "time": "2026-06-08T08:00:00.000+02:00",
+                                        "energy": 1.375,
+                                        "total": 1.8348,
+                                        "tax": 0.4598,
+                                        "difference": 40.92105431723749,
                                         "level": "HIGH"
                                     },
                                     {
-                                        "time": "2023-01-12T18:00:00.000+01:00",
-                                        "energy": 1.3137,
-                                        "total": 1.7791,
-                                        "tax": 0.4654,
-                                        "difference": 68.67196016914795,
+                                        "time": "2026-06-08T09:00:00.000+02:00",
+                                        "energy": 1.1858,
+                                        "total": 1.5982,
+                                        "tax": 0.4124,
+                                        "difference": 21.53031724318562,
                                         "level": "HIGH"
                                     },
                                     {
-                                        "time": "2023-01-12T19:00:00.000+01:00",
-                                        "energy": 1.1081,
-                                        "total": 1.5221,
-                                        "tax": 0.414,
-                                        "difference": 42.27403445492337,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-12T20:00:00.000+01:00",
-                                        "energy": 0.8345,
-                                        "total": 1.1801,
-                                        "tax": 0.3456,
-                                        "difference": 7.1452772787957315,
+                                        "time": "2026-06-08T10:00:00.000+02:00",
+                                        "energy": 1.0489,
+                                        "total": 1.4271,
+                                        "tax": 0.3782,
+                                        "difference": 7.499704635163937,
                                         "level": "NORMAL"
                                     },
                                     {
-                                        "time": "2023-01-12T21:00:00.000+01:00",
-                                        "energy": 0.8392,
-                                        "total": 1.186,
-                                        "tax": 0.3468,
-                                        "difference": 7.748731806309621,
+                                        "time": "2026-06-08T11:00:00.000+02:00",
+                                        "energy": 0.9123,
+                                        "total": 1.2564,
+                                        "tax": 0.3441,
+                                        "difference": -6.500161561006706,
                                         "level": "NORMAL"
                                     },
                                     {
-                                        "time": "2023-01-12T22:00:00.000+01:00",
-                                        "energy": 0.7529,
-                                        "total": 1.0782,
-                                        "tax": 0.3253,
-                                        "difference": -3.3317204754879413,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2023-01-12T23:00:00.000+01:00",
-                                        "energy": 0.4786,
-                                        "total": 0.7353,
-                                        "tax": 0.2567,
-                                        "difference": -38.55035385784106,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-13T00:00:00.000+01:00",
-                                        "energy": 0.3681,
-                                        "total": 0.5971,
-                                        "tax": 0.229,
-                                        "difference": -52.737954983433546,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-13T01:00:00.000+01:00",
-                                        "energy": 0.2466,
-                                        "total": 0.4453,
-                                        "tax": 0.1987,
-                                        "difference": -68.33789649256917,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-13T02:00:00.000+01:00",
-                                        "energy": 0.1865,
-                                        "total": 0.3701,
-                                        "tax": 0.1836,
-                                        "difference": -76.05441076992761,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-13T03:00:00.000+01:00",
-                                        "energy": 0.2082,
-                                        "total": 0.3972,
-                                        "tax": 0.189,
-                                        "difference": -73.26824837693796,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-13T04:00:00.000+01:00",
-                                        "energy": 0.2799,
-                                        "total": 0.4868,
-                                        "tax": 0.2069,
-                                        "difference": -64.0623569678431,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-13T05:00:00.000+01:00",
-                                        "energy": 0.3419,
-                                        "total": 0.5644,
-                                        "tax": 0.2225,
-                                        "difference": -56.10189298787267,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-13T06:00:00.000+01:00",
-                                        "energy": 0.6325,
-                                        "total": 0.9276,
-                                        "tax": 0.2951,
-                                        "difference": -18.790427946269276,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-13T07:00:00.000+01:00",
-                                        "energy": 0.9672,
-                                        "total": 1.346,
-                                        "tax": 0.3788,
-                                        "difference": 24.183238087538925,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-13T08:00:00.000+01:00",
-                                        "energy": 1.078,
-                                        "total": 1.4845,
-                                        "tax": 0.4065,
-                                        "difference": 38.409357587228044,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-13T09:00:00.000+01:00",
-                                        "energy": 1.1077,
-                                        "total": 1.5216,
-                                        "tax": 0.4139,
-                                        "difference": 42.222676622794495,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-13T10:00:00.000+01:00",
-                                        "energy": 1.044,
-                                        "total": 1.442,
-                                        "tax": 0.398,
-                                        "difference": 34.04394185627652,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-13T11:00:00.000+01:00",
-                                        "energy": 0.9577,
-                                        "total": 1.3341,
-                                        "tax": 0.3764,
-                                        "difference": 22.963489574478928,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-13T12:00:00.000+01:00",
-                                        "energy": 0.863,
-                                        "total": 1.2157,
-                                        "tax": 0.3527,
-                                        "difference": 10.804522817975709,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-13T13:00:00.000+01:00",
-                                        "energy": 0.8116,
-                                        "total": 1.1515,
-                                        "tax": 0.3399,
-                                        "difference": 4.205041389419549,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2023-01-13T14:00:00.000+01:00",
-                                        "energy": 0.8498,
-                                        "total": 1.1992,
+                                        "time": "2026-06-08T12:00:00.000+02:00",
+                                        "energy": 0.9337,
+                                        "total": 1.2831,
                                         "tax": 0.3494,
-                                        "difference": 9.109714357723917,
+                                        "difference": -4.306917515632975,
                                         "level": "NORMAL"
                                     },
                                     {
-                                        "time": "2023-01-13T15:00:00.000+01:00",
-                                        "energy": 0.9226,
-                                        "total": 1.2903,
-                                        "tax": 0.3677,
-                                        "difference": 18.456839805173104,
+                                        "time": "2026-06-08T13:00:00.000+02:00",
+                                        "energy": 0.8898,
+                                        "total": 1.2283,
+                                        "tax": 0.3385,
+                                        "difference": -8.806142449834226,
+                                        "level": "NORMAL"
+                                    },
+                                    {
+                                        "time": "2026-06-08T14:00:00.000+02:00",
+                                        "energy": 0.9065,
+                                        "total": 1.2492,
+                                        "tax": 0.3427,
+                                        "difference": -7.094592190126704,
+                                        "level": "NORMAL"
+                                    },
+                                    {
+                                        "time": "2026-06-08T15:00:00.000+02:00",
+                                        "energy": 1.005,
+                                        "total": 1.3723,
+                                        "tax": 0.3673,
+                                        "difference": 3.0004797009626714,
+                                        "level": "NORMAL"
+                                    },
+                                    {
+                                        "time": "2026-06-08T16:00:00.000+02:00",
+                                        "energy": 1.1275,
+                                        "total": 1.5254,
+                                        "tax": 0.3979,
+                                        "difference": 15.555264540134743,
                                         "level": "HIGH"
                                     },
                                     {
-                                        "time": "2023-01-13T16:00:00.000+01:00",
-                                        "energy": 0.962,
-                                        "total": 1.3395,
-                                        "tax": 0.3775,
-                                        "difference": 23.515586269863988,
+                                        "time": "2026-06-08T17:00:00.000+02:00",
+                                        "energy": 1.3627,
+                                        "total": 1.8194,
+                                        "tax": 0.4567,
+                                        "difference": 39.66045143134514,
                                         "level": "HIGH"
                                     },
                                     {
-                                        "time": "2023-01-13T17:00:00.000+01:00",
-                                        "energy": 1.0927,
-                                        "total": 1.5029,
-                                        "tax": 0.4102,
-                                        "difference": 40.296757917962964,
+                                        "time": "2026-06-08T18:00:00.000+02:00",
+                                        "energy": 1.629,
+                                        "total": 2.1523,
+                                        "tax": 0.5233,
+                                        "difference": 66.95301635111264,
                                         "level": "HIGH"
                                     },
                                     {
-                                        "time": "2023-01-13T18:00:00.000+01:00",
-                                        "energy": 1.0848,
-                                        "total": 1.493,
-                                        "tax": 0.4082,
-                                        "difference": 39.282440733418355,
+                                        "time": "2026-06-08T19:00:00.000+02:00",
+                                        "energy": 2.0519,
+                                        "total": 2.6808,
+                                        "tax": 0.6289,
+                                        "difference": 110.29520825711973,
                                         "level": "HIGH"
                                     },
                                     {
-                                        "time": "2023-01-13T19:00:00.000+01:00",
-                                        "energy": 1.027,
-                                        "total": 1.4207,
-                                        "tax": 0.3937,
-                                        "difference": 31.861233990800713,
+                                        "time": "2026-06-08T20:00:00.000+02:00",
+                                        "energy": 2.0151,
+                                        "total": 2.6349,
+                                        "tax": 0.6198,
+                                        "difference": 106.52364840339294,
                                         "level": "HIGH"
                                     },
                                     {
-                                        "time": "2023-01-13T20:00:00.000+01:00",
-                                        "energy": 0.9578,
-                                        "total": 1.3343,
-                                        "tax": 0.3765,
-                                        "difference": 22.976329032511146,
+                                        "time": "2026-06-08T21:00:00.000+02:00",
+                                        "energy": 1.8638,
+                                        "total": 2.4458,
+                                        "tax": 0.582,
+                                        "difference": 91.01720802652162,
                                         "level": "HIGH"
                                     },
                                     {
-                                        "time": "2023-01-13T21:00:00.000+01:00",
-                                        "energy": 0.867,
-                                        "total": 1.2208,
-                                        "tax": 0.3538,
-                                        "difference": 11.318101139264101,
+                                        "time": "2026-06-08T22:00:00.000+02:00",
+                                        "energy": 1.5232,
+                                        "total": 2.02,
+                                        "tax": 0.4968,
+                                        "difference": 56.10978177164813,
                                         "level": "HIGH"
                                     },
                                     {
-                                        "time": "2023-01-13T22:00:00.000+01:00",
-                                        "energy": 0.8628,
-                                        "total": 1.2154,
-                                        "tax": 0.3526,
-                                        "difference": 10.778843901911287,
+                                        "time": "2026-06-08T23:00:00.000+02:00",
+                                        "energy": 1.2178,
+                                        "total": 1.6383,
+                                        "tax": 0.4205,
+                                        "difference": 24.80993450729588,
                                         "level": "HIGH"
                                     },
                                     {
-                                        "time": "2023-01-13T23:00:00.000+01:00",
-                                        "energy": 0.7702,
-                                        "total": 1.0997,
-                                        "tax": 0.3295,
-                                        "difference": -1.110494235915553,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2023-01-14T00:00:00.000+01:00",
-                                        "energy": 0.5594,
-                                        "total": 0.8363,
-                                        "tax": 0.2769,
-                                        "difference": -28.17607176781506,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-14T01:00:00.000+01:00",
-                                        "energy": 0.4978,
-                                        "total": 0.7593,
-                                        "tax": 0.2615,
-                                        "difference": -36.085177915656665,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-14T02:00:00.000+01:00",
-                                        "energy": 0.511,
-                                        "total": 0.7758,
-                                        "tax": 0.2648,
-                                        "difference": -34.390369455404894,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-14T03:00:00.000+01:00",
-                                        "energy": 0.4755,
-                                        "total": 0.7313,
-                                        "tax": 0.2558,
-                                        "difference": -38.948377056839576,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-14T04:00:00.000+01:00",
-                                        "energy": 0.4693,
-                                        "total": 0.7236,
-                                        "tax": 0.2543,
-                                        "difference": -39.74442345483662,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-14T05:00:00.000+01:00",
-                                        "energy": 0.469,
-                                        "total": 0.7233,
-                                        "tax": 0.2543,
-                                        "difference": -39.78294182893326,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-14T06:00:00.000+01:00",
-                                        "energy": 0.5075,
-                                        "total": 0.7714,
-                                        "tax": 0.2639,
-                                        "difference": -34.83975048653227,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-14T07:00:00.000+01:00",
-                                        "energy": 0.6009,
-                                        "total": 0.8882,
-                                        "tax": 0.2873,
-                                        "difference": -22.847696684447754,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-14T08:00:00.000+01:00",
-                                        "energy": 0.6035,
-                                        "total": 0.8914,
-                                        "tax": 0.2879,
-                                        "difference": -22.513870775610272,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-14T09:00:00.000+01:00",
-                                        "energy": 0.6402,
-                                        "total": 0.9373,
-                                        "tax": 0.2971,
-                                        "difference": -17.80178967778906,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-14T10:00:00.000+01:00",
-                                        "energy": 0.7508,
-                                        "total": 1.0755,
-                                        "tax": 0.3247,
-                                        "difference": -3.6013490941643624,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2023-01-14T11:00:00.000+01:00",
-                                        "energy": 0.7378,
-                                        "total": 1.0592,
-                                        "tax": 0.3214,
-                                        "difference": -5.270478638351719,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2023-01-14T12:00:00.000+01:00",
-                                        "energy": 0.7359,
-                                        "total": 1.0568,
-                                        "tax": 0.3209,
-                                        "difference": -5.514428340963718,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2023-01-14T13:00:00.000+01:00",
-                                        "energy": 0.7055,
-                                        "total": 1.0188,
-                                        "tax": 0.3133,
-                                        "difference": -9.417623582755681,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2023-01-14T14:00:00.000+01:00",
-                                        "energy": 0.7535,
-                                        "total": 1.0789,
-                                        "tax": 0.3254,
-                                        "difference": -3.2546837272946902,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2023-01-14T15:00:00.000+01:00",
-                                        "energy": 0.8324,
-                                        "total": 1.1775,
-                                        "tax": 0.3451,
-                                        "difference": 6.87564866011931,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2023-01-14T16:00:00.000+01:00",
-                                        "energy": 0.8542,
-                                        "total": 1.2048,
-                                        "tax": 0.3506,
-                                        "difference": 9.67465051114118,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2023-01-14T17:00:00.000+01:00",
-                                        "energy": 0.8286,
-                                        "total": 1.1727,
-                                        "tax": 0.3441,
-                                        "difference": 6.387749254895311,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2023-01-14T18:00:00.000+01:00",
-                                        "energy": 0.7822,
-                                        "total": 1.1148,
-                                        "tax": 0.3326,
-                                        "difference": 0.4302407279497089,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2023-01-14T19:00:00.000+01:00",
-                                        "energy": 0.7057,
-                                        "total": 1.0191,
-                                        "tax": 0.3134,
-                                        "difference": -9.39194466669126,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2023-01-14T20:00:00.000+01:00",
-                                        "energy": 0.5799,
-                                        "total": 0.8619,
-                                        "tax": 0.282,
-                                        "difference": -25.543982871211938,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-14T21:00:00.000+01:00",
-                                        "energy": 0.4916,
-                                        "total": 0.7514,
-                                        "tax": 0.2598,
-                                        "difference": -36.8812243136537,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-14T22:00:00.000+01:00",
-                                        "energy": 0.4507,
-                                        "total": 0.7004,
-                                        "tax": 0.2497,
-                                        "difference": -42.13256264882775,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-14T23:00:00.000+01:00",
-                                        "energy": 0.3975,
-                                        "total": 0.6338,
-                                        "tax": 0.2363,
-                                        "difference": -48.963154321963685,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-15T00:00:00.000+01:00",
-                                        "energy": 0.3086,
-                                        "total": 0.5227,
-                                        "tax": 0.2141,
-                                        "difference": -60.37743251259873,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-15T01:00:00.000+01:00",
-                                        "energy": 0.3066,
-                                        "total": 0.5203,
-                                        "tax": 0.2137,
-                                        "difference": -60.63422167324293,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-15T02:00:00.000+01:00",
-                                        "energy": 0.2734,
-                                        "total": 0.4788,
-                                        "tax": 0.2054,
-                                        "difference": -64.89692173993679,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-15T03:00:00.000+01:00",
-                                        "energy": 0.1464,
-                                        "total": 0.32,
-                                        "tax": 0.1736,
-                                        "difference": -81.20303344084398,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-15T04:00:00.000+01:00",
-                                        "energy": 0.0899,
-                                        "total": 0.2493,
-                                        "tax": 0.1594,
-                                        "difference": -88.45732722904286,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-15T05:00:00.000+01:00",
-                                        "energy": 0.0546,
-                                        "total": 0.2053,
-                                        "tax": 0.1507,
-                                        "difference": -92.98965591441312,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-15T06:00:00.000+01:00",
-                                        "energy": 0.0681,
-                                        "total": 0.2222,
-                                        "tax": 0.1541,
-                                        "difference": -91.25632908006472,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-15T07:00:00.000+01:00",
-                                        "energy": 0.1136,
-                                        "total": 0.279,
-                                        "tax": 0.1654,
-                                        "difference": -85.41437567540899,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-15T08:00:00.000+01:00",
-                                        "energy": 0.158,
-                                        "total": 0.3345,
-                                        "tax": 0.1765,
-                                        "difference": -79.71365630910758,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-15T09:00:00.000+01:00",
-                                        "energy": 0.2148,
-                                        "total": 0.4054,
-                                        "tax": 0.1906,
-                                        "difference": -72.42084414681207,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-15T10:00:00.000+01:00",
-                                        "energy": 0.2008,
-                                        "total": 0.388,
-                                        "tax": 0.1872,
-                                        "difference": -74.21836827132152,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-15T11:00:00.000+01:00",
-                                        "energy": 0.1318,
-                                        "total": 0.3017,
-                                        "tax": 0.1699,
-                                        "difference": -83.0775943135467,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-15T12:00:00.000+01:00",
-                                        "energy": 0.078,
-                                        "total": 0.2346,
-                                        "tax": 0.1566,
-                                        "difference": -89.98522273487589,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-15T13:00:00.000+01:00",
-                                        "energy": 0.068,
-                                        "total": 0.222,
-                                        "tax": 0.154,
-                                        "difference": -91.26916853809693,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-15T14:00:00.000+01:00",
-                                        "energy": 0.0686,
-                                        "total": 0.2227,
-                                        "tax": 0.1541,
-                                        "difference": -91.19213178990367,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-15T15:00:00.000+01:00",
-                                        "energy": 0.2151,
-                                        "total": 0.4058,
-                                        "tax": 0.1907,
-                                        "difference": -72.38232577271545,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-15T16:00:00.000+01:00",
-                                        "energy": 0.3089,
-                                        "total": 0.5231,
-                                        "tax": 0.2142,
-                                        "difference": -60.33891413850209,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-15T17:00:00.000+01:00",
-                                        "energy": 0.348,
-                                        "total": 0.572,
-                                        "tax": 0.224,
-                                        "difference": -55.31868604790783,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-15T18:00:00.000+01:00",
-                                        "energy": 0.3109,
-                                        "total": 0.5256,
-                                        "tax": 0.2147,
-                                        "difference": -60.08212497785789,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-15T19:00:00.000+01:00",
-                                        "energy": 0.2917,
-                                        "total": 0.5016,
-                                        "tax": 0.2099,
-                                        "difference": -62.54730092004228,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-15T20:00:00.000+01:00",
-                                        "energy": 0.1404,
-                                        "total": 0.3125,
-                                        "tax": 0.1721,
-                                        "difference": -81.9734009227766,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-15T21:00:00.000+01:00",
-                                        "energy": 0.2341,
-                                        "total": 0.4296,
-                                        "tax": 0.1955,
-                                        "difference": -69.94282874659547,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-15T22:00:00.000+01:00",
-                                        "energy": 0.3495,
-                                        "total": 0.5739,
-                                        "tax": 0.2244,
-                                        "difference": -55.126094177424676,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-15T23:00:00.000+01:00",
-                                        "energy": 0.3646,
-                                        "total": 0.5928,
-                                        "tax": 0.2282,
-                                        "difference": -53.18733601456091,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-16T00:00:00.000+01:00",
-                                        "energy": 0.3981,
-                                        "total": 0.6346,
-                                        "tax": 0.2365,
-                                        "difference": -48.88611757377043,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-16T01:00:00.000+01:00",
-                                        "energy": 0.4069,
-                                        "total": 0.6456,
-                                        "tax": 0.2387,
-                                        "difference": -47.75624526693591,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-16T02:00:00.000+01:00",
-                                        "energy": 0.4069,
-                                        "total": 0.6456,
-                                        "tax": 0.2387,
-                                        "difference": -47.75624526693591,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-16T03:00:00.000+01:00",
-                                        "energy": 0.4343,
-                                        "total": 0.6799,
-                                        "tax": 0.2456,
-                                        "difference": -44.238233766110255,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-16T04:00:00.000+01:00",
-                                        "energy": 0.4708,
-                                        "total": 0.7255,
-                                        "tax": 0.2547,
-                                        "difference": -39.55183158435347,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-16T05:00:00.000+01:00",
-                                        "energy": 0.5134,
-                                        "total": 0.7787,
-                                        "tax": 0.2653,
-                                        "difference": -34.08222246263183,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-16T06:00:00.000+01:00",
-                                        "energy": 0.7524,
-                                        "total": 1.0774,
-                                        "tax": 0.325,
-                                        "difference": -3.3959177656490027,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2023-01-16T07:00:00.000+01:00",
-                                        "energy": 0.9755,
-                                        "total": 1.3564,
-                                        "tax": 0.3809,
-                                        "difference": 25.248913104212406,
+                                        "time": "2026-06-09T00:00:00.000+02:00",
+                                        "energy": 1.2146,
+                                        "total": 1.6343,
+                                        "tax": 0.4197,
+                                        "difference": 24.481972780884846,
                                         "level": "HIGH"
                                     },
                                     {
-                                        "time": "2023-01-16T08:00:00.000+01:00",
-                                        "energy": 1.0061,
-                                        "total": 1.3946,
+                                        "time": "2026-06-09T01:00:00.000+02:00",
+                                        "energy": 1.1464,
+                                        "total": 1.5489,
+                                        "tax": 0.4025,
+                                        "difference": 17.492288486749885,
+                                        "level": "HIGH"
+                                    },
+                                    {
+                                        "time": "2026-06-09T02:00:00.000+02:00",
+                                        "energy": 1.0902,
+                                        "total": 1.4787,
                                         "tax": 0.3885,
-                                        "difference": 29.17778726206876,
+                                        "difference": 11.732460666656237,
                                         "level": "HIGH"
                                     },
                                     {
-                                        "time": "2023-01-16T09:00:00.000+01:00",
-                                        "energy": 1.0243,
-                                        "total": 1.4174,
-                                        "tax": 0.3931,
-                                        "difference": 31.51456862393104,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-16T10:00:00.000+01:00",
-                                        "energy": 1.1118,
-                                        "total": 1.5268,
-                                        "tax": 0.415,
-                                        "difference": 42.749094402115134,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-16T11:00:00.000+01:00",
-                                        "energy": 1.1191,
-                                        "total": 1.5359,
-                                        "tax": 0.4168,
-                                        "difference": 43.68637483846652,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-16T12:00:00.000+01:00",
-                                        "energy": 1.0135,
-                                        "total": 1.4039,
-                                        "tax": 0.3904,
-                                        "difference": 30.127907156452352,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-16T13:00:00.000+01:00",
-                                        "energy": 1.2376,
-                                        "total": 1.684,
-                                        "tax": 0.4464,
-                                        "difference": 58.90113260663583,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-16T14:00:00.000+01:00",
-                                        "energy": 1.5412,
-                                        "total": 2.0635,
-                                        "tax": 0.5223,
-                                        "difference": 97.88172719242658,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-16T15:00:00.000+01:00",
-                                        "energy": 1.5897,
-                                        "total": 2.1241,
-                                        "tax": 0.5344,
-                                        "difference": 104.10886433804859,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-16T16:00:00.000+01:00",
-                                        "energy": 1.6457,
-                                        "total": 2.1941,
-                                        "tax": 0.5484,
-                                        "difference": 111.29896083608645,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-16T17:00:00.000+01:00",
-                                        "energy": 1.4629,
-                                        "total": 1.9656,
-                                        "tax": 0.5027,
-                                        "difference": 87.82843155320586,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-16T18:00:00.000+01:00",
-                                        "energy": 1.0012,
-                                        "total": 1.3885,
-                                        "tax": 0.3873,
-                                        "difference": 28.548653818490465,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-16T19:00:00.000+01:00",
-                                        "energy": 0.9013,
-                                        "total": 1.2637,
-                                        "tax": 0.3624,
-                                        "difference": 15.72203524431228,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-16T20:00:00.000+01:00",
-                                        "energy": 0.7422,
-                                        "total": 1.0648,
-                                        "tax": 0.3226,
-                                        "difference": -4.705542484934469,
+                                        "time": "2026-06-09T03:00:00.000+02:00",
+                                        "energy": 1.0665,
+                                        "total": 1.4492,
+                                        "tax": 0.3827,
+                                        "difference": 9.303494130424568,
                                         "level": "NORMAL"
                                     },
                                     {
-                                        "time": "2023-01-16T21:00:00.000+01:00",
-                                        "energy": 0.6722,
-                                        "total": 0.9772,
-                                        "tax": 0.305,
-                                        "difference": -13.693163107481737,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-16T22:00:00.000+01:00",
-                                        "energy": 0.577,
-                                        "total": 0.8583,
-                                        "tax": 0.2813,
-                                        "difference": -25.916327154146032,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-16T23:00:00.000+01:00",
-                                        "energy": 0.5239,
-                                        "total": 0.7918,
-                                        "tax": 0.2679,
-                                        "difference": -32.73407936924974,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-17T00:00:00.000+01:00",
-                                        "energy": 0.5316,
-                                        "total": 0.8015,
-                                        "tax": 0.2699,
-                                        "difference": -31.745441100769554,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-17T01:00:00.000+01:00",
-                                        "energy": 0.4843,
-                                        "total": 0.7424,
-                                        "tax": 0.2581,
-                                        "difference": -37.81850475000507,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-17T02:00:00.000+01:00",
-                                        "energy": 0.4754,
-                                        "total": 0.7313,
-                                        "tax": 0.2559,
-                                        "difference": -38.961216514871786,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-17T03:00:00.000+01:00",
-                                        "energy": 0.4602,
-                                        "total": 0.7122,
-                                        "tax": 0.252,
-                                        "difference": -40.912814135767775,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-17T04:00:00.000+01:00",
-                                        "energy": 0.4694,
-                                        "total": 0.7238,
-                                        "tax": 0.2544,
-                                        "difference": -39.73158399680442,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-17T05:00:00.000+01:00",
-                                        "energy": 0.516,
-                                        "total": 0.782,
-                                        "tax": 0.266,
-                                        "difference": -33.748396553794365,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-17T06:00:00.000+01:00",
-                                        "energy": 0.6786,
-                                        "total": 0.9853,
-                                        "tax": 0.3067,
-                                        "difference": -12.87143779342027,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-17T07:00:00.000+01:00",
-                                        "energy": 0.7993,
-                                        "total": 1.1362,
-                                        "tax": 0.3369,
-                                        "difference": 2.6257880514576755,
+                                        "time": "2026-06-09T04:00:00.000+02:00",
+                                        "energy": 1.0644,
+                                        "total": 1.4466,
+                                        "tax": 0.3822,
+                                        "difference": 9.088269247467352,
                                         "level": "NORMAL"
                                     },
                                     {
-                                        "time": "2023-01-17T08:00:00.000+01:00",
-                                        "energy": 0.8275,
-                                        "total": 1.1714,
-                                        "tax": 0.3439,
-                                        "difference": 6.246515216540999,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2023-01-17T09:00:00.000+01:00",
-                                        "energy": 0.8191,
-                                        "total": 1.1608,
-                                        "tax": 0.3417,
-                                        "difference": 5.168000741835343,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2023-01-17T10:00:00.000+01:00",
-                                        "energy": 0.8341,
-                                        "total": 1.1796,
-                                        "tax": 0.3455,
-                                        "difference": 7.093919446666888,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2023-01-17T11:00:00.000+01:00",
-                                        "energy": 0.8589,
-                                        "total": 1.2106,
-                                        "tax": 0.3517,
-                                        "difference": 10.27810503865507,
+                                        "time": "2026-06-09T05:00:00.000+02:00",
+                                        "energy": 1.2108,
+                                        "total": 1.6295,
+                                        "tax": 0.4187,
+                                        "difference": 24.09251823077176,
                                         "level": "HIGH"
                                     },
                                     {
-                                        "time": "2023-01-17T12:00:00.000+01:00",
-                                        "energy": 0.9019,
-                                        "total": 1.2643,
-                                        "tax": 0.3624,
-                                        "difference": 15.799071992505546,
+                                        "time": "2026-06-09T06:00:00.000+02:00",
+                                        "energy": 1.4147,
+                                        "total": 1.8843,
+                                        "tax": 0.4696,
+                                        "difference": 44.9898294855243,
                                         "level": "HIGH"
                                     },
                                     {
-                                        "time": "2023-01-17T13:00:00.000+01:00",
-                                        "energy": 0.8472,
-                                        "total": 1.196,
-                                        "tax": 0.3488,
-                                        "difference": 8.775888448886434,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2023-01-17T14:00:00.000+01:00",
-                                        "energy": 0.8144,
-                                        "total": 1.1551,
-                                        "tax": 0.3407,
-                                        "difference": 4.564546214321453,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2023-01-17T15:00:00.000+01:00",
-                                        "energy": 0.8524,
-                                        "total": 1.2024,
-                                        "tax": 0.35,
-                                        "difference": 9.4435402665614,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2023-01-17T16:00:00.000+01:00",
-                                        "energy": 0.8575,
-                                        "total": 1.2089,
-                                        "tax": 0.3514,
-                                        "difference": 10.098352626204132,
+                                        "time": "2026-06-09T07:00:00.000+02:00",
+                                        "energy": 1.5077,
+                                        "total": 2.0006,
+                                        "tax": 0.4929,
+                                        "difference": 54.52121715934473,
                                         "level": "HIGH"
                                     },
                                     {
-                                        "time": "2023-01-17T17:00:00.000+01:00",
-                                        "energy": 0.8635,
-                                        "total": 1.2164,
-                                        "tax": 0.3529,
-                                        "difference": 10.868720108136756,
+                                        "time": "2026-06-09T08:00:00.000+02:00",
+                                        "energy": 1.3918,
+                                        "total": 1.8558,
+                                        "tax": 0.464,
+                                        "difference": 42.64285338089536,
                                         "level": "HIGH"
                                     },
                                     {
-                                        "time": "2023-01-17T18:00:00.000+01:00",
-                                        "energy": 0.8286,
-                                        "total": 1.1727,
-                                        "tax": 0.3441,
-                                        "difference": 6.387749254895311,
+                                        "time": "2026-06-09T09:00:00.000+02:00",
+                                        "energy": 1.2016,
+                                        "total": 1.618,
+                                        "tax": 0.4164,
+                                        "difference": 23.149628267340063,
+                                        "level": "HIGH"
+                                    },
+                                    {
+                                        "time": "2026-06-09T10:00:00.000+02:00",
+                                        "energy": 0.9272,
+                                        "total": 1.2751,
+                                        "tax": 0.3479,
+                                        "difference": -4.973089772405373,
                                         "level": "NORMAL"
                                     },
                                     {
-                                        "time": "2023-01-17T19:00:00.000+01:00",
-                                        "energy": 0.7578,
-                                        "total": 1.0843,
-                                        "tax": 0.3265,
-                                        "difference": -2.70258703190963,
+                                        "time": "2026-06-09T11:00:00.000+02:00",
+                                        "energy": 0.7007,
+                                        "total": 0.9919,
+                                        "tax": 0.2912,
+                                        "difference": -28.186630719935764,
+                                        "level": "LOW"
+                                    },
+                                    {
+                                        "time": "2026-06-09T12:00:00.000+02:00",
+                                        "energy": 0.4163,
+                                        "total": 0.6364,
+                                        "tax": 0.2201,
+                                        "difference": -57.33422915471566,
+                                        "level": "LOW"
+                                    },
+                                    {
+                                        "time": "2026-06-09T13:00:00.000+02:00",
+                                        "energy": 0.4145,
+                                        "total": 0.6341,
+                                        "tax": 0.2196,
+                                        "difference": -57.51870762582186,
+                                        "level": "LOW"
+                                    },
+                                    {
+                                        "time": "2026-06-09T14:00:00.000+02:00",
+                                        "energy": 0.3937,
+                                        "total": 0.6081,
+                                        "tax": 0.2144,
+                                        "difference": -59.650458847493525,
+                                        "level": "LOW"
+                                    },
+                                    {
+                                        "time": "2026-06-09T15:00:00.000+02:00",
+                                        "energy": 0.3973,
+                                        "total": 0.6126,
+                                        "tax": 0.2153,
+                                        "difference": -59.28150190528112,
+                                        "level": "LOW"
+                                    },
+                                    {
+                                        "time": "2026-06-09T16:00:00.000+02:00",
+                                        "energy": 0.4731,
+                                        "total": 0.7074,
+                                        "tax": 0.2343,
+                                        "difference": -51.51290851091995,
+                                        "level": "LOW"
+                                    },
+                                    {
+                                        "time": "2026-06-09T17:00:00.000+02:00",
+                                        "energy": 0.879,
+                                        "total": 1.2147,
+                                        "tax": 0.3357,
+                                        "difference": -9.913013276471446,
                                         "level": "NORMAL"
                                     },
                                     {
-                                        "time": "2023-01-17T20:00:00.000+01:00",
-                                        "energy": 0.6783,
-                                        "total": 0.9849,
-                                        "tax": 0.3066,
-                                        "difference": -12.909956167516896,
+                                        "time": "2026-06-09T18:00:00.000+02:00",
+                                        "energy": 1.3234,
+                                        "total": 1.7702,
+                                        "tax": 0.4468,
+                                        "difference": 35.63267147885972,
+                                        "level": "HIGH"
+                                    },
+                                    {
+                                        "time": "2026-06-09T19:00:00.000+02:00",
+                                        "energy": 1.4032,
+                                        "total": 1.87,
+                                        "tax": 0.4668,
+                                        "difference": 43.81121703123466,
+                                        "level": "HIGH"
+                                    },
+                                    {
+                                        "time": "2026-06-09T20:00:00.000+02:00",
+                                        "energy": 1.363,
+                                        "total": 1.8197,
+                                        "tax": 0.4567,
+                                        "difference": 39.691197843196136,
+                                        "level": "HIGH"
+                                    },
+                                    {
+                                        "time": "2026-06-09T21:00:00.000+02:00",
+                                        "energy": 1.2134,
+                                        "total": 1.6328,
+                                        "tax": 0.4194,
+                                        "difference": 24.358987133480724,
+                                        "level": "HIGH"
+                                    },
+                                    {
+                                        "time": "2026-06-09T22:00:00.000+02:00",
+                                        "energy": 1.0722,
+                                        "total": 1.4562,
+                                        "tax": 0.384,
+                                        "difference": 9.887675955594204,
+                                        "level": "NORMAL"
+                                    },
+                                    {
+                                        "time": "2026-06-09T23:00:00.000+02:00",
+                                        "energy": 0.9642,
+                                        "total": 1.3214,
+                                        "tax": 0.3572,
+                                        "difference": -1.1810323107778942,
+                                        "level": "NORMAL"
+                                    },
+                                    {
+                                        "time": "2026-06-10T00:00:00.000+02:00",
+                                        "energy": 0.7738,
+                                        "total": 1.0832,
+                                        "tax": 0.3094,
+                                        "difference": -20.6947550322339,
                                         "level": "LOW"
                                     },
                                     {
-                                        "time": "2023-01-17T21:00:00.000+01:00",
-                                        "energy": 0.606,
-                                        "total": 0.8945,
-                                        "tax": 0.2885,
-                                        "difference": -22.19288432480502,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-17T22:00:00.000+01:00",
-                                        "energy": 0.5348,
-                                        "total": 0.8056,
-                                        "tax": 0.2708,
-                                        "difference": -31.33457844373882,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-17T23:00:00.000+01:00",
-                                        "energy": 0.4888,
-                                        "total": 0.748,
-                                        "tax": 0.2592,
-                                        "difference": -37.240729138555594,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-18T00:00:00.000+01:00",
-                                        "energy": 0.45,
-                                        "total": 0.6995,
-                                        "tax": 0.2495,
-                                        "difference": -42.22243885505323,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-18T01:00:00.000+01:00",
-                                        "energy": 0.4375,
-                                        "total": 0.6838,
-                                        "tax": 0.2463,
-                                        "difference": -43.82737110907953,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-18T02:00:00.000+01:00",
-                                        "energy": 0.4369,
-                                        "total": 0.6831,
-                                        "tax": 0.2462,
-                                        "difference": -43.90440785727279,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-18T03:00:00.000+01:00",
-                                        "energy": 0.4327,
-                                        "total": 0.6779,
-                                        "tax": 0.2452,
-                                        "difference": -44.44366509462563,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-18T04:00:00.000+01:00",
-                                        "energy": 0.4822,
-                                        "total": 0.7397,
-                                        "tax": 0.2575,
-                                        "difference": -38.088133368681476,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-18T05:00:00.000+01:00",
-                                        "energy": 0.588,
-                                        "total": 0.872,
+                                        "time": "2026-06-10T01:00:00.000+02:00",
+                                        "energy": 0.6719,
+                                        "total": 0.9559,
                                         "tax": 0.284,
-                                        "difference": -24.503986770602893,
+                                        "difference": -31.138286257635002,
                                         "level": "LOW"
                                     },
                                     {
-                                        "time": "2023-01-18T06:00:00.000+01:00",
-                                        "energy": 0.7543,
-                                        "total": 1.0799,
-                                        "tax": 0.3256,
-                                        "difference": -3.1519680630370033,
+                                        "time": "2026-06-10T02:00:00.000+02:00",
+                                        "energy": 0.7937,
+                                        "total": 1.1081,
+                                        "tax": 0.3144,
+                                        "difference": -18.655243046115345,
+                                        "level": "LOW"
+                                    },
+                                    {
+                                        "time": "2026-06-10T03:00:00.000+02:00",
+                                        "energy": 0.712,
+                                        "total": 1.006,
+                                        "tax": 0.294,
+                                        "difference": -27.028515873546837,
+                                        "level": "LOW"
+                                    },
+                                    {
+                                        "time": "2026-06-10T04:00:00.000+02:00",
+                                        "energy": 0.6569,
+                                        "total": 0.9371,
+                                        "tax": 0.2802,
+                                        "difference": -32.67560685018668,
+                                        "level": "LOW"
+                                    },
+                                    {
+                                        "time": "2026-06-10T05:00:00.000+02:00",
+                                        "energy": 0.6192,
+                                        "total": 0.89,
+                                        "tax": 0.2708,
+                                        "difference": -36.539405939466576,
+                                        "level": "LOW"
+                                    },
+                                    {
+                                        "time": "2026-06-10T06:00:00.000+02:00",
+                                        "energy": 0.8254,
+                                        "total": 1.1478,
+                                        "tax": 0.3224,
+                                        "difference": -15.406372193856129,
+                                        "level": "LOW"
+                                    },
+                                    {
+                                        "time": "2026-06-10T07:00:00.000+02:00",
+                                        "energy": 0.9639,
+                                        "total": 1.3209,
+                                        "tax": 0.357,
+                                        "difference": -1.2117787226289352,
                                         "level": "NORMAL"
                                     },
                                     {
-                                        "time": "2023-01-18T07:00:00.000+01:00",
-                                        "energy": 0.9031,
-                                        "total": 1.2658,
-                                        "tax": 0.3627,
-                                        "difference": 15.953145488892062,
-                                        "level": "HIGH"
+                                        "time": "2026-06-10T08:00:00.000+02:00",
+                                        "energy": 0.8202,
+                                        "total": 1.1413,
+                                        "tax": 0.3211,
+                                        "difference": -15.93930999927403,
+                                        "level": "LOW"
                                     },
                                     {
-                                        "time": "2023-01-18T08:00:00.000+01:00",
-                                        "energy": 0.9323,
-                                        "total": 1.3024,
-                                        "tax": 0.3701,
-                                        "difference": 19.70226723429751,
-                                        "level": "HIGH"
+                                        "time": "2026-06-10T09:00:00.000+02:00",
+                                        "energy": 0.5304,
+                                        "total": 0.779,
+                                        "tax": 0.2486,
+                                        "difference": -45.640343847372534,
+                                        "level": "LOW"
                                     },
                                     {
-                                        "time": "2023-01-18T09:00:00.000+01:00",
-                                        "energy": 0.9317,
-                                        "total": 1.3017,
-                                        "tax": 0.37,
-                                        "difference": 19.62523048610423,
-                                        "level": "HIGH"
+                                        "time": "2026-06-10T10:00:00.000+02:00",
+                                        "energy": 0.4247,
+                                        "total": 0.6469,
+                                        "tax": 0.2222,
+                                        "difference": -56.473329622886716,
+                                        "level": "LOW"
                                     },
                                     {
-                                        "time": "2023-01-18T10:00:00.000+01:00",
-                                        "energy": 1.0154,
-                                        "total": 1.4063,
-                                        "tax": 0.3909,
-                                        "difference": 30.371856859064337,
-                                        "level": "HIGH"
+                                        "time": "2026-06-10T11:00:00.000+02:00",
+                                        "energy": 0.2895,
+                                        "total": 0.478,
+                                        "tax": 0.1885,
+                                        "difference": -70.32971256375254,
+                                        "level": "LOW"
                                     },
                                     {
-                                        "time": "2023-01-18T11:00:00.000+01:00",
-                                        "energy": 1.1174,
-                                        "total": 1.5337,
-                                        "tax": 0.4163,
-                                        "difference": 43.468104051918914,
-                                        "level": "HIGH"
+                                        "time": "2026-06-10T12:00:00.000+02:00",
+                                        "energy": 0.2048,
+                                        "total": 0.372,
+                                        "tax": 0.1672,
+                                        "difference": -79.01044950969437,
+                                        "level": "LOW"
                                     },
                                     {
-                                        "time": "2023-01-18T12:00:00.000+01:00",
-                                        "energy": 1.2414,
-                                        "total": 1.6887,
-                                        "tax": 0.4473,
-                                        "difference": 59.389032011859825,
-                                        "level": "HIGH"
+                                        "time": "2026-06-10T13:00:00.000+02:00",
+                                        "energy": 0.1473,
+                                        "total": 0.3001,
+                                        "tax": 0.1528,
+                                        "difference": -84.90351178114248,
+                                        "level": "LOW"
                                     },
                                     {
-                                        "time": "2023-01-18T13:00:00.000+01:00",
-                                        "energy": 1.3499,
-                                        "total": 1.8244,
-                                        "tax": 0.4745,
-                                        "difference": 73.3198439768081,
-                                        "level": "HIGH"
+                                        "time": "2026-06-10T14:00:00.000+02:00",
+                                        "energy": 0.1085,
+                                        "total": 0.2516,
+                                        "tax": 0.1431,
+                                        "difference": -88.88004771387617,
+                                        "level": "LOW"
                                     },
                                     {
-                                        "time": "2023-01-18T14:00:00.000+01:00",
-                                        "energy": 1.3964,
-                                        "total": 1.8825,
-                                        "tax": 0.4861,
-                                        "difference": 79.29019196178595,
-                                        "level": "HIGH"
+                                        "time": "2026-06-10T15:00:00.000+02:00",
+                                        "energy": 0.3134,
+                                        "total": 0.5078,
+                                        "tax": 0.1944,
+                                        "difference": -67.88024841962019,
+                                        "level": "LOW"
                                     },
                                     {
-                                        "time": "2023-01-18T15:00:00.000+01:00",
-                                        "energy": 1.4996,
-                                        "total": 2.0116,
-                                        "tax": 0.512,
-                                        "difference": 92.54051265102709,
-                                        "level": "HIGH"
+                                        "time": "2026-06-10T16:00:00.000+02:00",
+                                        "energy": 0.5707,
+                                        "total": 0.8294,
+                                        "tax": 0.2587,
+                                        "difference": -41.510075855383676,
+                                        "level": "LOW"
                                     },
                                     {
-                                        "time": "2023-01-18T16:00:00.000+01:00",
-                                        "energy": 1.6174,
-                                        "total": 2.1588,
-                                        "tax": 0.5414,
-                                        "difference": 107.66539421297088,
-                                        "level": "HIGH"
+                                        "time": "2026-06-10T17:00:00.000+02:00",
+                                        "energy": 0.7334,
+                                        "total": 1.0328,
+                                        "tax": 0.2994,
+                                        "difference": -24.835271828173106,
+                                        "level": "LOW"
                                     },
                                     {
-                                        "time": "2023-01-18T17:00:00.000+01:00",
-                                        "energy": 1.6812,
-                                        "total": 2.2385,
-                                        "tax": 0.5573,
-                                        "difference": 115.85696843752115,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-18T18:00:00.000+01:00",
-                                        "energy": 1.5525,
-                                        "total": 2.0776,
-                                        "tax": 0.5251,
-                                        "difference": 99.33258595006635,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-18T19:00:00.000+01:00",
-                                        "energy": 1.4357,
-                                        "total": 1.9317,
-                                        "tax": 0.496,
-                                        "difference": 84.33609896844462,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-18T20:00:00.000+01:00",
-                                        "energy": 1.366,
-                                        "total": 1.8446,
-                                        "tax": 0.4786,
-                                        "difference": 75.38699671999399,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-18T21:00:00.000+01:00",
-                                        "energy": 1.354,
-                                        "total": 1.8295,
-                                        "tax": 0.4755,
-                                        "difference": 73.84626175612874,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-18T22:00:00.000+01:00",
-                                        "energy": 0.9293,
-                                        "total": 1.2986,
-                                        "tax": 0.3693,
-                                        "difference": 19.317083493331182,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-18T23:00:00.000+01:00",
-                                        "energy": 0.8556,
-                                        "total": 1.2065,
-                                        "tax": 0.3509,
-                                        "difference": 9.854402923592119,
+                                        "time": "2026-06-10T18:00:00.000+02:00",
+                                        "energy": 0.8869,
+                                        "total": 1.2246,
+                                        "tax": 0.3377,
+                                        "difference": -9.103357764394232,
                                         "level": "NORMAL"
                                     },
                                     {
-                                        "time": "2023-01-19T00:00:00.000+01:00",
-                                        "energy": 0.9333,
-                                        "total": 1.3036,
-                                        "tax": 0.3703,
-                                        "difference": 19.830661814619617,
+                                        "time": "2026-06-10T19:00:00.000+02:00",
+                                        "energy": 1.0531,
+                                        "total": 1.4324,
+                                        "tax": 0.3793,
+                                        "difference": 7.930154401078397,
+                                        "level": "NORMAL"
+                                    },
+                                    {
+                                        "time": "2026-06-10T20:00:00.000+02:00",
+                                        "energy": 1.1981,
+                                        "total": 1.6137,
+                                        "tax": 0.4156,
+                                        "difference": 22.79092012907799,
                                         "level": "HIGH"
                                     },
                                     {
-                                        "time": "2023-01-19T01:00:00.000+01:00",
-                                        "energy": 0.9279,
-                                        "total": 1.2969,
-                                        "tax": 0.369,
-                                        "difference": 19.13733108088023,
+                                        "time": "2026-06-10T21:00:00.000+02:00",
+                                        "energy": 1.1574,
+                                        "total": 1.5628,
+                                        "tax": 0.4054,
+                                        "difference": 18.61965692128777,
                                         "level": "HIGH"
                                     },
                                     {
-                                        "time": "2023-01-19T02:00:00.000+01:00",
-                                        "energy": 0.9237,
-                                        "total": 1.2916,
-                                        "tax": 0.3679,
-                                        "difference": 18.598073843527402,
-                                        "level": "HIGH"
+                                        "time": "2026-06-10T22:00:00.000+02:00",
+                                        "energy": 1.0412,
+                                        "total": 1.4174,
+                                        "tax": 0.3762,
+                                        "difference": 6.710546730987389,
+                                        "level": "NORMAL"
                                     },
                                     {
-                                        "time": "2023-01-19T03:00:00.000+01:00",
-                                        "energy": 0.9485,
-                                        "total": 1.3226,
-                                        "tax": 0.3741,
-                                        "difference": 21.7822594355156,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-19T04:00:00.000+01:00",
-                                        "energy": 1.037,
-                                        "total": 1.4332,
-                                        "tax": 0.3962,
-                                        "difference": 33.14517979402177,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-19T05:00:00.000+01:00",
-                                        "energy": 1.1723,
-                                        "total": 1.6024,
-                                        "tax": 0.4301,
-                                        "difference": 50.51696651160242,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-19T06:00:00.000+01:00",
-                                        "energy": 1.3204,
-                                        "total": 1.7875,
-                                        "tax": 0.4671,
-                                        "difference": 69.53220385730603,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-19T07:00:00.000+01:00",
-                                        "energy": 1.6711,
-                                        "total": 2.2259,
-                                        "tax": 0.5548,
-                                        "difference": 114.56018317626788,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-19T08:00:00.000+01:00",
-                                        "energy": 1.7863,
-                                        "total": 2.3699,
-                                        "tax": 0.5836,
-                                        "difference": 129.35123882937427,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-19T09:00:00.000+01:00",
-                                        "energy": 1.741,
-                                        "total": 2.3133,
-                                        "tax": 0.5723,
-                                        "difference": 123.53496434078295,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-19T10:00:00.000+01:00",
-                                        "energy": 1.7291,
-                                        "total": 2.2984,
-                                        "tax": 0.5693,
-                                        "difference": 122.00706883494993,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-19T11:00:00.000+01:00",
-                                        "energy": 1.5484,
-                                        "total": 2.0725,
-                                        "tax": 0.5241,
-                                        "difference": 98.80616817074574,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-19T12:00:00.000+01:00",
-                                        "energy": 1.636,
-                                        "total": 2.1819,
-                                        "tax": 0.5459,
-                                        "difference": 110.05353340696203,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-19T13:00:00.000+01:00",
-                                        "energy": 1.6883,
-                                        "total": 2.2474,
-                                        "tax": 0.5591,
-                                        "difference": 116.76856995780804,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-19T14:00:00.000+01:00",
-                                        "energy": 1.7351,
-                                        "total": 2.3059,
-                                        "tax": 0.5708,
-                                        "difference": 122.77743631688253,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-19T15:00:00.000+01:00",
-                                        "energy": 1.9024,
-                                        "total": 2.5151,
-                                        "tax": 0.6127,
-                                        "difference": 144.2578496047705,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-19T16:00:00.000+01:00",
-                                        "energy": 2.0141,
-                                        "total": 2.6547,
-                                        "tax": 0.6406,
-                                        "difference": 158.59952422674957,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-19T17:00:00.000+01:00",
-                                        "energy": 1.9406,
-                                        "total": 2.5628,
-                                        "tax": 0.6222,
-                                        "difference": 149.1625225730749,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-19T18:00:00.000+01:00",
-                                        "energy": 1.7492,
-                                        "total": 2.3235,
-                                        "tax": 0.5743,
-                                        "difference": 124.58779989942423,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-19T19:00:00.000+01:00",
-                                        "energy": 1.6927,
-                                        "total": 2.2529,
-                                        "tax": 0.5602,
-                                        "difference": 117.33350611122532,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-19T20:00:00.000+01:00",
-                                        "energy": 1.6268,
-                                        "total": 2.1705,
-                                        "tax": 0.5437,
-                                        "difference": 108.87230326799872,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-19T21:00:00.000+01:00",
-                                        "energy": 1.6046,
-                                        "total": 2.1427,
-                                        "tax": 0.5381,
-                                        "difference": 106.02194358484795,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-19T22:00:00.000+01:00",
-                                        "energy": 1.3291,
-                                        "total": 1.7984,
-                                        "tax": 0.4693,
-                                        "difference": 70.64923670610835,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-19T23:00:00.000+01:00",
-                                        "energy": 1.1863,
-                                        "total": 1.6198,
-                                        "tax": 0.4335,
-                                        "difference": 52.314490636111884,
-                                        "level": "HIGH"
+                                        "time": "2026-06-10T23:00:00.000+02:00",
+                                        "energy": 0.9194,
+                                        "total": 1.2653,
+                                        "tax": 0.3459,
+                                        "difference": -5.772496480532254,
+                                        "level": "NORMAL"
                                     }
                                 ]
                             },
                             "daily": {
-                                "minEnergy": 0.0968,
-                                "maxEnergy": 2.3178,
-                                "minTotal": 0.2304,
-                                "maxTotal": 3.0067,
+                                "minEnergy": 0.1905,
+                                "maxEnergy": 1.4159,
+                                "minTotal": 0.3541,
+                                "maxTotal": 1.8859,
                                 "currency": "SEK",
                                 "entries": [
                                     {
-                                        "time": "2022-12-19T00:00:00.000+01:00",
-                                        "energy": 2.0465,
-                                        "total": 2.6675,
-                                        "tax": 0.621,
-                                        "difference": 101.22230381839356,
+                                        "time": "2026-05-11T00:00:00.000+02:00",
+                                        "energy": 1.2143,
+                                        "total": 1.6338,
+                                        "tax": 0.4195,
+                                        "difference": 45.29268273855013,
                                         "level": "HIGH"
                                     },
                                     {
-                                        "time": "2022-12-20T00:00:00.000+01:00",
-                                        "energy": 2.0339,
-                                        "total": 2.6517,
-                                        "tax": 0.6178,
-                                        "difference": 99.9834076404743,
+                                        "time": "2026-05-12T00:00:00.000+02:00",
+                                        "energy": 1.156,
+                                        "total": 1.561,
+                                        "tax": 0.405,
+                                        "difference": 38.317006708197255,
                                         "level": "HIGH"
                                     },
                                     {
-                                        "time": "2022-12-21T00:00:00.000+01:00",
-                                        "energy": 2.3178,
-                                        "total": 3.0067,
-                                        "tax": 0.6889,
-                                        "difference": 127.89790168105185,
+                                        "time": "2026-05-13T00:00:00.000+02:00",
+                                        "energy": 1.0397,
+                                        "total": 1.4157,
+                                        "tax": 0.376,
+                                        "difference": 24.401550064457368,
                                         "level": "HIGH"
                                     },
                                     {
-                                        "time": "2022-12-22T00:00:00.000+01:00",
-                                        "energy": 2.0752,
-                                        "total": 2.7034,
-                                        "tax": 0.6282,
-                                        "difference": 104.0442340014319,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2022-12-23T00:00:00.000+01:00",
-                                        "energy": 1.8635,
-                                        "total": 2.4388,
-                                        "tax": 0.5753,
-                                        "difference": 83.22881171051864,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2022-12-24T00:00:00.000+01:00",
-                                        "energy": 1.2575,
-                                        "total": 1.6812,
-                                        "tax": 0.4237,
-                                        "difference": 23.643805058211527,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2022-12-25T00:00:00.000+01:00",
-                                        "energy": 1.0743,
-                                        "total": 1.4523,
-                                        "tax": 0.378,
-                                        "difference": 5.630647931639501,
-                                        "level": "NORMAL"
-                                    },
-                                    {
-                                        "time": "2022-12-26T00:00:00.000+01:00",
-                                        "energy": 0.3933,
-                                        "total": 0.6009,
-                                        "tax": 0.2076,
-                                        "difference": -61.328740732091774,
+                                        "time": "2026-05-14T00:00:00.000+02:00",
+                                        "energy": 0.5719,
+                                        "total": 0.8309,
+                                        "tax": 0.259,
+                                        "difference": -31.571370124205885,
                                         "level": "LOW"
                                     },
                                     {
-                                        "time": "2022-12-27T00:00:00.000+01:00",
-                                        "energy": 0.8694,
-                                        "total": 1.1962,
+                                        "time": "2026-05-15T00:00:00.000+02:00",
+                                        "energy": 0.9737,
+                                        "total": 1.3332,
+                                        "tax": 0.3595,
+                                        "difference": 16.50455833198241,
+                                        "level": "HIGH"
+                                    },
+                                    {
+                                        "time": "2026-05-16T00:00:00.000+02:00",
+                                        "energy": 0.9027,
+                                        "total": 1.2444,
+                                        "tax": 0.3417,
+                                        "difference": 8.009309650077554,
+                                        "level": "NORMAL"
+                                    },
+                                    {
+                                        "time": "2026-05-17T00:00:00.000+02:00",
+                                        "energy": 0.7188,
+                                        "total": 1.0145,
+                                        "tax": 0.2957,
+                                        "difference": -13.994580949954852,
+                                        "level": "LOW"
+                                    },
+                                    {
+                                        "time": "2026-05-18T00:00:00.000+02:00",
+                                        "energy": 1.264,
+                                        "total": 1.6961,
+                                        "tax": 0.4321,
+                                        "difference": 51.239356815883525,
+                                        "level": "HIGH"
+                                    },
+                                    {
+                                        "time": "2026-05-19T00:00:00.000+02:00",
+                                        "energy": 1.0104,
+                                        "total": 1.3791,
+                                        "tax": 0.3687,
+                                        "difference": 20.895764340798024,
+                                        "level": "HIGH"
+                                    },
+                                    {
+                                        "time": "2026-05-20T00:00:00.000+02:00",
+                                        "energy": 0.8614,
+                                        "total": 1.1927,
+                                        "tax": 0.3313,
+                                        "difference": 3.067707247786444,
+                                        "level": "NORMAL"
+                                    },
+                                    {
+                                        "time": "2026-05-21T00:00:00.000+02:00",
+                                        "energy": 1.0022,
+                                        "total": 1.3688,
+                                        "tax": 0.3666,
+                                        "difference": 19.914622943732965,
+                                        "level": "HIGH"
+                                    },
+                                    {
+                                        "time": "2026-05-22T00:00:00.000+02:00",
+                                        "energy": 0.9023,
+                                        "total": 1.2438,
+                                        "tax": 0.3415,
+                                        "difference": 7.961449094123168,
+                                        "level": "NORMAL"
+                                    },
+                                    {
+                                        "time": "2026-05-23T00:00:00.000+02:00",
+                                        "energy": 0.3717,
+                                        "total": 0.5807,
+                                        "tax": 0.209,
+                                        "difference": -55.52557837937982,
+                                        "level": "LOW"
+                                    },
+                                    {
+                                        "time": "2026-05-24T00:00:00.000+02:00",
+                                        "energy": 0.1905,
+                                        "total": 0.3541,
+                                        "tax": 0.1636,
+                                        "difference": -77.2064102267201,
+                                        "level": "LOW"
+                                    },
+                                    {
+                                        "time": "2026-05-25T00:00:00.000+02:00",
+                                        "energy": 0.4179,
+                                        "total": 0.6384,
+                                        "tax": 0.2205,
+                                        "difference": -49.997684166647375,
+                                        "level": "LOW"
+                                    },
+                                    {
+                                        "time": "2026-05-26T00:00:00.000+02:00",
+                                        "energy": 0.4704,
+                                        "total": 0.704,
+                                        "tax": 0.2336,
+                                        "difference": -43.71598619763323,
+                                        "level": "LOW"
+                                    },
+                                    {
+                                        "time": "2026-05-27T00:00:00.000+02:00",
+                                        "energy": 0.4053,
+                                        "total": 0.6226,
+                                        "tax": 0.2173,
+                                        "difference": -51.50529167921077,
+                                        "level": "LOW"
+                                    },
+                                    {
+                                        "time": "2026-05-28T00:00:00.000+02:00",
+                                        "energy": 0.6755,
+                                        "total": 0.9604,
+                                        "tax": 0.2849,
+                                        "difference": -19.17548613201795,
+                                        "level": "LOW"
+                                    },
+                                    {
+                                        "time": "2026-05-29T00:00:00.000+02:00",
+                                        "energy": 0.7428,
+                                        "total": 1.0445,
+                                        "tax": 0.3017,
+                                        "difference": -11.122947592691233,
+                                        "level": "LOW"
+                                    },
+                                    {
+                                        "time": "2026-05-30T00:00:00.000+02:00",
+                                        "energy": 0.7232,
+                                        "total": 1.02,
+                                        "tax": 0.2968,
+                                        "difference": -13.468114834456529,
+                                        "level": "LOW"
+                                    },
+                                    {
+                                        "time": "2026-05-31T00:00:00.000+02:00",
+                                        "energy": 0.8942,
+                                        "total": 1.2338,
+                                        "tax": 0.3396,
+                                        "difference": 6.992272836046709,
+                                        "level": "NORMAL"
+                                    },
+                                    {
+                                        "time": "2026-06-01T00:00:00.000+02:00",
+                                        "energy": 1.4159,
+                                        "total": 1.8859,
+                                        "tax": 0.47,
+                                        "difference": 69.41440293956444,
+                                        "level": "HIGH"
+                                    },
+                                    {
+                                        "time": "2026-06-02T00:00:00.000+02:00",
+                                        "energy": 1.3097,
+                                        "total": 1.7531,
+                                        "tax": 0.4434,
+                                        "difference": 56.707425333673,
+                                        "level": "HIGH"
+                                    },
+                                    {
+                                        "time": "2026-06-03T00:00:00.000+02:00",
+                                        "energy": 1.1011,
+                                        "total": 1.4924,
+                                        "tax": 0.3913,
+                                        "difference": 31.748145403456732,
+                                        "level": "HIGH"
+                                    },
+                                    {
+                                        "time": "2026-06-04T00:00:00.000+02:00",
+                                        "energy": 0.567,
+                                        "total": 0.8248,
+                                        "tax": 0.2578,
+                                        "difference": -32.157661934647194,
+                                        "level": "LOW"
+                                    },
+                                    {
+                                        "time": "2026-06-05T00:00:00.000+02:00",
+                                        "energy": 0.8798,
+                                        "total": 1.2157,
+                                        "tax": 0.3359,
+                                        "difference": 5.269292821688552,
+                                        "level": "NORMAL"
+                                    },
+                                    {
+                                        "time": "2026-06-06T00:00:00.000+02:00",
+                                        "energy": 0.8432,
+                                        "total": 1.17,
                                         "tax": 0.3268,
-                                        "difference": -14.516163723571282,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2022-12-28T00:00:00.000+01:00",
-                                        "energy": 0.7843,
-                                        "total": 1.0897,
-                                        "tax": 0.3054,
-                                        "difference": -22.883629179200554,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2022-12-29T00:00:00.000+01:00",
-                                        "energy": 0.2914,
-                                        "total": 0.4737,
-                                        "tax": 0.1823,
-                                        "difference": -71.34806775828005,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2022-12-30T00:00:00.000+01:00",
-                                        "energy": 0.1981,
-                                        "total": 0.3569,
-                                        "tax": 0.1588,
-                                        "difference": -80.52179898049168,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2022-12-31T00:00:00.000+01:00",
-                                        "energy": 0.0968,
-                                        "total": 0.2304,
-                                        "tax": 0.1336,
-                                        "difference": -90.48213095058857,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-01T00:00:00.000+01:00",
-                                        "energy": 0.2038,
-                                        "total": 0.3918,
-                                        "tax": 0.188,
-                                        "difference": -79.96134594762344,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-02T00:00:00.000+01:00",
-                                        "energy": 1.3778,
-                                        "total": 1.8592,
-                                        "tax": 0.4814,
-                                        "difference": 35.47231380453587,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-03T00:00:00.000+01:00",
-                                        "energy": 1.4833,
-                                        "total": 1.9912,
-                                        "tax": 0.5079,
-                                        "difference": 45.845611167272494,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-04T00:00:00.000+01:00",
-                                        "energy": 0.8169,
-                                        "total": 1.1581,
-                                        "tax": 0.3412,
-                                        "difference": -19.678231131568197,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-05T00:00:00.000+01:00",
-                                        "energy": 1.2494,
-                                        "total": 1.6987,
-                                        "tax": 0.4493,
-                                        "difference": 22.84737180097774,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-06T00:00:00.000+01:00",
-                                        "energy": 1.1843,
-                                        "total": 1.6173,
-                                        "tax": 0.433,
-                                        "difference": 16.446408215061552,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-07T00:00:00.000+01:00",
-                                        "energy": 0.8473,
-                                        "total": 1.1962,
-                                        "tax": 0.3489,
-                                        "difference": -16.689148289604262,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-08T00:00:00.000+01:00",
-                                        "energy": 0.4325,
-                                        "total": 0.6776,
-                                        "tax": 0.2451,
-                                        "difference": -57.474397067454085,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-09T00:00:00.000+01:00",
-                                        "energy": 1.3274,
-                                        "total": 1.7963,
-                                        "tax": 0.4689,
-                                        "difference": 30.51672909285884,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-10T00:00:00.000+01:00",
-                                        "energy": 1.3109,
-                                        "total": 1.7756,
-                                        "tax": 0.4647,
-                                        "difference": 28.894365050345527,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2023-01-11T00:00:00.000+01:00",
-                                        "energy": 0.6358,
-                                        "total": 0.9318,
-                                        "tax": 0.296,
-                                        "difference": -37.484905561820355,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-12T00:00:00.000+01:00",
-                                        "energy": 0.6574,
-                                        "total": 0.9588,
-                                        "tax": 0.3014,
-                                        "difference": -35.36108354253021,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-13T00:00:00.000+01:00",
-                                        "energy": 0.7704,
-                                        "total": 1.1,
-                                        "tax": 0.3296,
-                                        "difference": -24.250347978651163,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-14T00:00:00.000+01:00",
-                                        "energy": 0.6225,
-                                        "total": 0.9151,
-                                        "tax": 0.2926,
-                                        "difference": -38.792629305179574,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-15T00:00:00.000+01:00",
-                                        "energy": 0.2018,
-                                        "total": 0.3893,
-                                        "tax": 0.1875,
-                                        "difference": -80.15799613459475,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-16T00:00:00.000+01:00",
-                                        "energy": 0.897,
-                                        "total": 1.2582,
-                                        "tax": 0.3612,
-                                        "difference": -11.802391143367203,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-17T00:00:00.000+01:00",
-                                        "energy": 0.6994,
-                                        "total": 1.0113,
-                                        "tax": 0.3119,
-                                        "difference": -31.231429616132672,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2023-01-18T00:00:00.000+01:00",
-                                        "energy": 1.0317,
-                                        "total": 1.4266,
-                                        "tax": 0.3949,
-                                        "difference": 1.4419989491505874,
+                                        "difference": 0.8900519518615368,
                                         "level": "NORMAL"
                                     },
                                     {
-                                        "time": "2023-01-19T00:00:00.000+01:00",
-                                        "energy": 1.4935,
-                                        "total": 2.0039,
-                                        "tax": 0.5104,
-                                        "difference": 46.84852712082619,
+                                        "time": "2026-06-07T00:00:00.000+02:00",
+                                        "energy": 0.3558,
+                                        "total": 0.5607,
+                                        "tax": 0.2049,
+                                        "difference": -57.42803547856696,
+                                        "level": "LOW"
+                                    },
+                                    {
+                                        "time": "2026-06-08T00:00:00.000+02:00",
+                                        "energy": 1.2328,
+                                        "total": 1.657,
+                                        "tax": 0.4242,
+                                        "difference": 47.50623345144081,
                                         "level": "HIGH"
+                                    },
+                                    {
+                                        "time": "2026-06-09T00:00:00.000+02:00",
+                                        "energy": 1.0104,
+                                        "total": 1.379,
+                                        "tax": 0.3686,
+                                        "difference": 20.895764340798024,
+                                        "level": "HIGH"
+                                    },
+                                    {
+                                        "time": "2026-06-10T00:00:00.000+02:00",
+                                        "energy": 0.684,
+                                        "total": 0.971,
+                                        "tax": 0.287,
+                                        "difference": -18.158449317987078,
+                                        "level": "LOW"
                                     }
                                 ]
                             },
                             "monthly": {
-                                "minEnergy": 0.0926,
-                                "maxEnergy": 2.6902,
-                                "minTotal": 0.1401,
-                                "maxTotal": 3.4721,
+                                "minEnergy": 0.0854,
+                                "maxEnergy": 1.1023,
+                                "minTotal": 0.2068,
+                                "maxTotal": 1.4939,
                                 "currency": "SEK",
                                 "entries": [
                                     {
-                                        "time": "2020-02-01T00:00:00.000+01:00",
-                                        "energy": 0.1946,
-                                        "total": 0.2682,
-                                        "tax": 0.0736,
-                                        "difference": -74.8091520706506,
+                                        "time": "2023-07-01T00:00:00.000+02:00",
+                                        "energy": 0.3765,
+                                        "total": 0.5768,
+                                        "tax": 0.2003,
+                                        "difference": -28.87615509343074,
                                         "level": "LOW"
                                     },
                                     {
-                                        "time": "2020-03-01T00:00:00.000+01:00",
-                                        "energy": 0.1496,
-                                        "total": 0.2114,
-                                        "tax": 0.0618,
-                                        "difference": -80.63437384259676,
+                                        "time": "2023-08-01T00:00:00.000+02:00",
+                                        "energy": 0.3696,
+                                        "total": 0.5657,
+                                        "tax": 0.1961,
+                                        "difference": -30.179619980164674,
                                         "level": "LOW"
                                     },
                                     {
-                                        "time": "2020-04-01T00:00:00.000+02:00",
-                                        "energy": 0.098,
-                                        "total": 0.1469,
-                                        "tax": 0.0489,
-                                        "difference": -87.31396147442835,
+                                        "time": "2023-09-01T00:00:00.000+02:00",
+                                        "energy": 0.2432,
+                                        "total": 0.4268,
+                                        "tax": 0.1836,
+                                        "difference": -54.057585441493636,
                                         "level": "LOW"
                                     },
                                     {
-                                        "time": "2020-05-01T00:00:00.000+02:00",
-                                        "energy": 0.1354,
-                                        "total": 0.1937,
-                                        "tax": 0.0583,
-                                        "difference": -82.47255493507755,
+                                        "time": "2023-10-01T00:00:00.000+02:00",
+                                        "energy": 0.3306,
+                                        "total": 0.536,
+                                        "tax": 0.2054,
+                                        "difference": -37.547030209530405,
                                         "level": "LOW"
                                     },
                                     {
-                                        "time": "2020-06-01T00:00:00.000+02:00",
-                                        "energy": 0.2489,
-                                        "total": 0.3355,
-                                        "tax": 0.0866,
-                                        "difference": -67.78005113250222,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2020-07-01T00:00:00.000+02:00",
-                                        "energy": 0.0926,
-                                        "total": 0.1401,
-                                        "tax": 0.0475,
-                                        "difference": -88.0129880870619,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2020-08-01T00:00:00.000+02:00",
-                                        "energy": 0.3471,
-                                        "total": 0.4582,
-                                        "tax": 0.1111,
-                                        "difference": -55.0681227323886,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2020-09-01T00:00:00.000+02:00",
-                                        "energy": 0.3485,
-                                        "total": 0.4575,
-                                        "tax": 0.109,
-                                        "difference": -54.886893610594726,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2020-10-01T00:00:00.000+02:00",
-                                        "energy": 0.2302,
-                                        "total": 0.3089,
-                                        "tax": 0.0787,
-                                        "difference": -70.20075440217764,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2020-11-01T00:00:00.000+01:00",
-                                        "energy": 0.2413,
-                                        "total": 0.3215,
-                                        "tax": 0.0802,
-                                        "difference": -68.76386636509758,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2020-12-01T00:00:00.000+01:00",
-                                        "energy": 0.3158,
-                                        "total": 0.4141,
-                                        "tax": 0.0983,
-                                        "difference": -59.11988809820893,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2021-01-01T00:00:00.000+01:00",
-                                        "energy": 0.4905,
-                                        "total": 0.6343,
-                                        "tax": 0.1438,
-                                        "difference": -36.50508268578684,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2021-02-01T00:00:00.000+01:00",
-                                        "energy": 0.5362,
-                                        "total": 0.6914,
-                                        "tax": 0.1552,
-                                        "difference": -30.589246352943732,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2021-03-01T00:00:00.000+01:00",
-                                        "energy": 0.3678,
-                                        "total": 0.4804,
-                                        "tax": 0.1126,
-                                        "difference": -52.38852071729337,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2021-04-01T00:00:00.000+02:00",
-                                        "energy": 0.3368,
-                                        "total": 0.4416,
-                                        "tax": 0.1048,
-                                        "difference": -56.40145127130073,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2021-05-01T00:00:00.000+02:00",
-                                        "energy": 0.435,
-                                        "total": 0.5653,
-                                        "tax": 0.1303,
-                                        "difference": -43.6895228711871,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2021-06-01T00:00:00.000+02:00",
-                                        "energy": 0.403,
-                                        "total": 0.5273,
-                                        "tax": 0.1243,
-                                        "difference": -47.83190279790437,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2021-07-01T00:00:00.000+02:00",
-                                        "energy": 0.5905,
-                                        "total": 0.761,
-                                        "tax": 0.1705,
-                                        "difference": -23.560145414795358,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2021-08-01T00:00:00.000+02:00",
-                                        "energy": 0.6711,
-                                        "total": 0.8627,
-                                        "tax": 0.1916,
-                                        "difference": -13.126525974376236,
-                                        "level": "LOW"
-                                    },
-                                    {
-                                        "time": "2021-09-01T00:00:00.000+02:00",
-                                        "energy": 0.9184,
-                                        "total": 1.1724,
-                                        "tax": 0.254,
-                                        "difference": 18.886303896785677,
+                                        "time": "2023-11-01T00:00:00.000+01:00",
+                                        "energy": 0.8213,
+                                        "total": 1.1489,
+                                        "tax": 0.3276,
+                                        "difference": 55.150103112258535,
                                         "level": "HIGH"
                                     },
                                     {
-                                        "time": "2021-10-01T00:00:00.000+02:00",
-                                        "energy": 0.6475,
-                                        "total": 0.8404,
-                                        "tax": 0.1929,
-                                        "difference": -16.18153117033023,
-                                        "level": "LOW"
+                                        "time": "2023-12-01T00:00:00.000+01:00",
+                                        "energy": 0.7917,
+                                        "total": 1.1117,
+                                        "tax": 0.32,
+                                        "difference": 49.558427656124536,
+                                        "level": "HIGH"
                                     },
                                     {
-                                        "time": "2021-11-01T00:00:00.000+01:00",
-                                        "energy": 0.8352,
-                                        "total": 1.0696,
-                                        "tax": 0.2344,
-                                        "difference": 8.116116087320762,
+                                        "time": "2024-01-01T00:00:00.000+01:00",
+                                        "energy": 0.803,
+                                        "total": 1.1212,
+                                        "tax": 0.3182,
+                                        "difference": 51.693087543094634,
+                                        "level": "HIGH"
+                                    },
+                                    {
+                                        "time": "2024-02-01T00:00:00.000+01:00",
+                                        "energy": 0.5034,
+                                        "total": 0.7468,
+                                        "tax": 0.2434,
+                                        "difference": -4.903735654802205,
                                         "level": "NORMAL"
                                     },
                                     {
-                                        "time": "2021-12-01T00:00:00.000+01:00",
-                                        "energy": 1.8074,
-                                        "total": 2.2849,
-                                        "tax": 0.4775,
-                                        "difference": 133.96679623589984,
+                                        "time": "2024-03-01T00:00:00.000+01:00",
+                                        "energy": 0.5947,
+                                        "total": 0.8485,
+                                        "tax": 0.2538,
+                                        "difference": 12.343560600097604,
                                         "level": "HIGH"
                                     },
                                     {
-                                        "time": "2022-01-01T00:00:00.000+01:00",
-                                        "energy": 1.0433,
-                                        "total": 1.3353,
-                                        "tax": 0.292,
-                                        "difference": 35.05453054825401,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2022-02-01T00:00:00.000+01:00",
-                                        "energy": 0.7748,
-                                        "total": 1.0075,
-                                        "tax": 0.2327,
-                                        "difference": 0.2973739756419178,
+                                        "time": "2024-04-01T00:00:00.000+02:00",
+                                        "energy": 0.5631,
+                                        "total": 0.8052,
+                                        "tax": 0.2421,
+                                        "difference": 6.374069234765358,
                                         "level": "NORMAL"
                                     },
                                     {
-                                        "time": "2022-03-01T00:00:00.000+01:00",
-                                        "energy": 1.3033,
-                                        "total": 1.6692,
-                                        "tax": 0.3659,
-                                        "difference": 68.71136745283181,
+                                        "time": "2024-05-01T00:00:00.000+02:00",
+                                        "energy": 0.2371,
+                                        "total": 0.3964,
+                                        "tax": 0.1593,
+                                        "difference": -55.209923964548274,
+                                        "level": "LOW"
+                                    },
+                                    {
+                                        "time": "2024-06-01T00:00:00.000+02:00",
+                                        "energy": 0.2727,
+                                        "total": 0.4408,
+                                        "tax": 0.1681,
+                                        "difference": -48.48480078081955,
+                                        "level": "LOW"
+                                    },
+                                    {
+                                        "time": "2024-07-01T00:00:00.000+02:00",
+                                        "energy": 0.2072,
+                                        "total": 0.359,
+                                        "tax": 0.1518,
+                                        "difference": -60.85827180706202,
+                                        "level": "LOW"
+                                    },
+                                    {
+                                        "time": "2024-08-01T00:00:00.000+02:00",
+                                        "energy": 0.0854,
+                                        "total": 0.2068,
+                                        "tax": 0.1214,
+                                        "difference": -83.86726067723501,
+                                        "level": "LOW"
+                                    },
+                                    {
+                                        "time": "2024-09-01T00:00:00.000+02:00",
+                                        "energy": 0.1644,
+                                        "total": 0.3055,
+                                        "tax": 0.1411,
+                                        "difference": -68.94353226390442,
+                                        "level": "LOW"
+                                    },
+                                    {
+                                        "time": "2024-10-01T00:00:00.000+02:00",
+                                        "energy": 0.2297,
+                                        "total": 0.3821,
+                                        "tax": 0.1524,
+                                        "difference": -56.60784282858178,
+                                        "level": "LOW"
+                                    },
+                                    {
+                                        "time": "2024-11-01T00:00:00.000+01:00",
+                                        "energy": 0.6695,
+                                        "total": 0.9231,
+                                        "tax": 0.2536,
+                                        "difference": 26.473875604111868,
                                         "level": "HIGH"
                                     },
                                     {
-                                        "time": "2022-04-01T00:00:00.000+02:00",
-                                        "energy": 0.8922,
-                                        "total": 1.1576,
-                                        "tax": 0.2654,
-                                        "difference": 15.494730331785902,
+                                        "time": "2024-12-01T00:00:00.000+01:00",
+                                        "energy": 0.5825,
+                                        "total": 0.8144,
+                                        "tax": 0.2319,
+                                        "difference": 10.038883553988313,
                                         "level": "HIGH"
                                     },
                                     {
-                                        "time": "2022-05-01T00:00:00.000+02:00",
-                                        "energy": 1.0286,
-                                        "total": 1.3264,
-                                        "tax": 0.2978,
-                                        "difference": 33.15162476941828,
+                                        "time": "2025-01-01T00:00:00.000+01:00",
+                                        "energy": 0.6344,
+                                        "total": 0.8793,
+                                        "tax": 0.2449,
+                                        "difference": 19.843206397682707,
                                         "level": "HIGH"
                                     },
                                     {
-                                        "time": "2022-06-01T00:00:00.000+02:00",
-                                        "energy": 1.2631,
-                                        "total": 1.6191,
-                                        "tax": 0.356,
-                                        "difference": 63.507502669893256,
+                                        "time": "2025-02-01T00:00:00.000+01:00",
+                                        "energy": 0.7705,
+                                        "total": 1.0494,
+                                        "tax": 0.2789,
+                                        "difference": 45.55357901862317,
                                         "level": "HIGH"
                                     },
                                     {
-                                        "time": "2022-07-01T00:00:00.000+02:00",
-                                        "energy": 0.8661,
-                                        "total": 1.1275,
-                                        "tax": 0.2614,
-                                        "difference": 12.11610170405713,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2022-08-01T00:00:00.000+02:00",
-                                        "energy": 2.2305,
-                                        "total": 2.8397,
-                                        "tax": 0.6092,
-                                        "difference": 188.7368258294648,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2022-09-01T00:00:00.000+02:00",
-                                        "energy": 2.2863,
-                                        "total": 2.9324,
-                                        "tax": 0.6461,
-                                        "difference": 195.96010082667806,
-                                        "level": "HIGH"
-                                    },
-                                    {
-                                        "time": "2022-10-01T00:00:00.000+02:00",
-                                        "energy": 0.8065,
-                                        "total": 1.1039,
-                                        "tax": 0.2974,
-                                        "difference": 4.4009190905462106,
+                                        "time": "2025-03-01T00:00:00.000+01:00",
+                                        "energy": 0.5081,
+                                        "total": 0.7214,
+                                        "tax": 0.2133,
+                                        "difference": -4.015868268186338,
                                         "level": "NORMAL"
                                     },
                                     {
-                                        "time": "2022-11-01T00:00:00.000+01:00",
-                                        "energy": 1.3088,
-                                        "total": 1.7438,
-                                        "tax": 0.435,
-                                        "difference": 69.42333900273636,
+                                        "time": "2025-04-01T00:00:00.000+02:00",
+                                        "energy": 0.3761,
+                                        "total": 0.5561,
+                                        "tax": 0.18,
+                                        "difference": -28.95171827527038,
+                                        "level": "LOW"
+                                    },
+                                    {
+                                        "time": "2025-05-01T00:00:00.000+02:00",
+                                        "energy": 0.4294,
+                                        "total": 0.6228,
+                                        "tax": 0.1934,
+                                        "difference": -18.8829242951372,
+                                        "level": "LOW"
+                                    },
+                                    {
+                                        "time": "2025-06-01T00:00:00.000+02:00",
+                                        "energy": 0.2278,
+                                        "total": 0.3708,
+                                        "tax": 0.143,
+                                        "difference": -56.966767942320104,
+                                        "level": "LOW"
+                                    },
+                                    {
+                                        "time": "2025-07-01T00:00:00.000+02:00",
+                                        "energy": 0.3701,
+                                        "total": 0.5487,
+                                        "tax": 0.1786,
+                                        "difference": -30.085166002865122,
+                                        "level": "LOW"
+                                    },
+                                    {
+                                        "time": "2025-08-01T00:00:00.000+02:00",
+                                        "energy": 0.4856,
+                                        "total": 0.693,
+                                        "tax": 0.2074,
+                                        "difference": -8.266297246666582,
+                                        "level": "NORMAL"
+                                    },
+                                    {
+                                        "time": "2025-09-01T00:00:00.000+02:00",
+                                        "energy": 0.5233,
+                                        "total": 0.7401,
+                                        "tax": 0.2168,
+                                        "difference": -1.1444673582796838,
+                                        "level": "NORMAL"
+                                    },
+                                    {
+                                        "time": "2025-10-01T00:00:00.000+02:00",
+                                        "energy": 0.6281,
+                                        "total": 0.8711,
+                                        "tax": 0.243,
+                                        "difference": 18.653086283708248,
                                         "level": "HIGH"
                                     },
                                     {
-                                        "time": "2022-12-01T00:00:00.000+01:00",
-                                        "energy": 2.6902,
-                                        "total": 3.4721,
-                                        "tax": 0.7819,
-                                        "difference": 248.24470246421254,
+                                        "time": "2025-11-01T00:00:00.000+01:00",
+                                        "energy": 0.6964,
+                                        "total": 0.9566,
+                                        "tax": 0.2602,
+                                        "difference": 31.555499582828247,
                                         "level": "HIGH"
                                     },
                                     {
-                                        "time": "2023-01-01T00:00:00.000+01:00",
-                                        "energy": 0.875,
-                                        "total": 1.2307,
-                                        "tax": 0.3557,
-                                        "difference": 13.268201121175366,
+                                        "time": "2025-12-01T00:00:00.000+01:00",
+                                        "energy": 0.5168,
+                                        "total": 0.732,
+                                        "tax": 0.2152,
+                                        "difference": -2.372369063173977,
+                                        "level": "NORMAL"
+                                    },
+                                    {
+                                        "time": "2026-01-01T00:00:00.000+01:00",
+                                        "energy": 1.0845,
+                                        "total": 1.4716,
+                                        "tax": 0.3871,
+                                        "difference": 104.87067676274734,
+                                        "level": "HIGH"
+                                    },
+                                    {
+                                        "time": "2026-02-01T00:00:00.000+01:00",
+                                        "energy": 1.1023,
+                                        "total": 1.4939,
+                                        "tax": 0.3916,
+                                        "difference": 108.23323835461173,
+                                        "level": "HIGH"
+                                    },
+                                    {
+                                        "time": "2026-03-01T00:00:00.000+01:00",
+                                        "energy": 0.5866,
+                                        "total": 0.8493,
+                                        "tax": 0.2627,
+                                        "difference": 10.813406167844718,
+                                        "level": "HIGH"
+                                    },
+                                    {
+                                        "time": "2026-04-01T00:00:00.000+02:00",
+                                        "energy": 0.5608,
+                                        "total": 0.817,
+                                        "tax": 0.2562,
+                                        "difference": 5.9395809391873655,
+                                        "level": "NORMAL"
+                                    },
+                                    {
+                                        "time": "2026-05-01T00:00:00.000+02:00",
+                                        "energy": 0.7705,
+                                        "total": 1.0791,
+                                        "tax": 0.3086,
+                                        "difference": 45.55357901862317,
+                                        "level": "HIGH"
+                                    },
+                                    {
+                                        "time": "2026-06-01T00:00:00.000+02:00",
+                                        "energy": 0.94,
+                                        "total": 1.2909,
+                                        "tax": 0.3509,
+                                        "difference": 77.57347732317425,
                                         "level": "HIGH"
                                     }
                                 ]

--- a/tests/cached/test_account.py
+++ b/tests/cached/test_account.py
@@ -7,10 +7,6 @@ from tibber.types import Viewer
 from tibber.exceptions import UnauthenticatedException
 
 
-@pytest.fixture
-def unfetched_account():
-    return tibber.Account(tibber.DEMO_TOKEN, immediate_update=False)
-
 def test_getting_viewer(account):
     assert isinstance(account.viewer, Viewer)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,26 +1,67 @@
+"""Shared fixtures for the test suite.
+
+The default test suite runs fully offline: the account fixture is preloaded with
+recorded demo data and never opens a network connection. Tests that require the real
+Tibber API are marked "live" or "realtime" and are deselected by default (see the
+pytest configuration in pyproject.toml). Run them with:
+
+    uv run pytest -m "live or realtime"
+"""
+
+import json
+from pathlib import Path
+from unittest import mock
+
 import pytest
 
 import tibber
-import json
+from tibber.networking import QueryExecutor
+
+SAMPLE_DATA_FILE = Path(__file__).parent / "backup_demo_data.json"
+
+
+async def _offline_ainit(self, session):
+    """Replacement for QueryExecutor.__ainit__ that skips connecting to the API."""
+    self.session = session
+
+
+def create_offline_account() -> tibber.Account:
+    """Create an Account without opening any network connection.
+
+    Queries executed later (e.g. by tests marked "live") still work: the gql client
+    connects on demand for each query.
+    """
+    with mock.patch.object(QueryExecutor, "__ainit__", _offline_ainit):
+        return tibber.Account(tibber.DEMO_TOKEN, immediate_update=False)
+
 
 @pytest.fixture(scope="session")
-def account():
-    try:
-        account = tibber.Account(tibber.DEMO_TOKEN)
-        assert True
-    except Exception as e:
-        print(e)
-        print("############ USING BACKUP SAMPLE DATA INSTEAD ############")
-        account = tibber.Account(tibber.DEMO_TOKEN, immediate_update=False)
-        with open("./tests/backup_demo_data.json", "r") as f:
-            data = json.load(f)
-        account.update_cache(data)
+def sample_data() -> dict:
+    """Recorded demo account data, as returned by Account.fetch_all()."""
+    with open(SAMPLE_DATA_FILE) as f:
+        return json.load(f)
 
+
+@pytest.fixture(scope="session")
+def account(sample_data):
+    """An Account preloaded with the recorded demo data. Does not touch the network."""
+    account = create_offline_account()
+    account.update_cache(sample_data)
     return account
+
+
+@pytest.fixture
+def unfetched_account():
+    """An Account with an empty cache. Does not touch the network."""
+    return create_offline_account()
+
 
 @pytest.fixture(scope="session")
 def home(account):
     try:
         return account.homes[0]
-    except IndexError:
-        raise ValueError("The instanciated demo account does not have any homes. Cannot perform home tests.")
+    except IndexError as e:
+        raise ValueError(
+            "The recorded demo account data does not contain any homes. "
+            "Cannot perform home tests."
+        ) from e

--- a/tests/fetched/test_consumption.py
+++ b/tests/fetched/test_consumption.py
@@ -4,6 +4,8 @@ from datetime import timedelta
 
 import pytest
 
+pytestmark = pytest.mark.live
+
 import tibber
 
 

--- a/tests/fetched/test_production.py
+++ b/tests/fetched/test_production.py
@@ -4,6 +4,8 @@ from datetime import timedelta
 
 import pytest
 
+pytestmark = pytest.mark.live
+
 import tibber
 
 

--- a/tests/fetched/test_range.py
+++ b/tests/fetched/test_range.py
@@ -6,6 +6,8 @@ from datetime import timedelta
 
 import pytest
 
+pytestmark = pytest.mark.live
+
 import tibber
 
 

--- a/tests/realtime/test_live_measurements.py
+++ b/tests/realtime/test_live_measurements.py
@@ -7,12 +7,8 @@ import tibber
 from tibber import __version__
 from tibber.types.live_measurement import LiveMeasurement
 
+pytestmark = pytest.mark.realtime
 
-def test_adding_listener_with_unknown_event_raises_exception(home):
-    with pytest.raises(ValueError):
-        @home.event("invalid-event-name")
-        async def callback(data):
-            print(data)
 
 @pytest.mark.timeout(60)
 def test_starting_live_feed_with_no_listeners_shows_warning(caplog):

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -1,0 +1,54 @@
+"""Offline tests for the live measurement event registration and broadcasting."""
+import asyncio
+
+import pytest
+
+from tibber.types.home import TibberHome
+
+
+@pytest.fixture
+def fresh_home(account):
+    """A TibberHome with its own (empty) callback registry."""
+    return TibberHome(account.homes[0].cache, account)
+
+
+def test_adding_listener_with_unknown_event_raises_exception(fresh_home):
+    with pytest.raises(ValueError):
+        @fresh_home.event("invalid-event-name")
+        async def callback(data):
+            print(data)
+
+
+def test_adding_non_coroutine_listener_raises_exception(fresh_home):
+    with pytest.raises(ValueError):
+        @fresh_home.event("live_measurement")
+        def callback(data):
+            print(data)
+
+
+def test_event_decorator_returns_the_callback(fresh_home):
+    async def callback(data):
+        pass
+
+    assert fresh_home.event("live_measurement")(callback) is callback
+
+
+def test_broadcast_runs_all_registered_callbacks(fresh_home):
+    calls = []
+
+    @fresh_home.event("live_measurement")
+    async def first_callback(data):
+        calls.append(("first", data))
+
+    @fresh_home.event("live_measurement")
+    async def second_callback(data):
+        calls.append(("second", data))
+
+    asyncio.run(fresh_home.broadcast_event("live_measurement", "payload"))
+    assert ("first", "payload") in calls
+    assert ("second", "payload") in calls
+
+
+def test_broadcast_without_listeners_warns(fresh_home, caplog):
+    asyncio.run(fresh_home.broadcast_event("live_measurement", None))
+    assert "no listeners" in caplog.text

--- a/tests/unit/test_query_builder.py
+++ b/tests/unit/test_query_builder.py
@@ -1,0 +1,125 @@
+"""Offline tests locking the exact GraphQL queries QueryBuilder generates.
+
+These are golden tests: they assert the exact output strings so that internal
+refactors of the query building logic cannot silently change the queries sent to
+the Tibber API.
+"""
+import pytest
+
+from tibber.networking import QueryBuilder
+
+
+def test_create_query_from_dict_renders_nested_keys():
+    query = QueryBuilder.create_query_from_dict({"a": "", "b": {"c": ""}})
+    assert query == "{\n  a\n  b {\n    c\n  }\n}"
+
+
+def test_create_query_requires_at_least_one_argument():
+    with pytest.raises(TypeError):
+        QueryBuilder.create_query()
+
+
+def test_create_query_nests_arguments():
+    query = QueryBuilder.create_query(
+        "viewer", 'home(id: "abc")', {"appNickname": ""}
+    )
+    assert query == (
+        "{\n"
+        "  viewer {\n"
+        '    home(id: "abc") {\n'
+        "      appNickname\n"
+        "    }\n"
+        "  }\n"
+        "}"
+    )
+
+
+def test_query_all_data_queries_the_full_viewer():
+    query = QueryBuilder.query_all_data()
+    for expected_field in ["viewer", "homes", "currentSubscription", "priceInfo"]:
+        assert expected_field in query
+
+
+class TestCombineDicts:
+    def test_merges_nested_dicts(self):
+        result = QueryBuilder.combine_dicts(
+            {"a": "", "b": {"c": ""}}, {"b": {"d": ""}, "e": ""}
+        )
+        assert result == {"a": "", "b": {"c": "", "d": ""}, "e": ""}
+
+    def test_dict_value_overwrites_string_value(self):
+        assert QueryBuilder.combine_dicts({"a": ""}, {"a": {"x": ""}}) == {"a": {"x": ""}}
+
+    def test_dict_value_is_kept_over_string_value(self):
+        assert QueryBuilder.combine_dicts({"a": {"x": ""}}, {"a": ""}) == {"a": {"x": ""}}
+
+    def test_second_string_value_wins(self):
+        assert QueryBuilder.combine_dicts({"a": "1"}, {"a": "2"}) == {"a": "2"}
+
+    def test_non_dicts_raise_type_error(self):
+        with pytest.raises(TypeError):
+            QueryBuilder.combine_dicts("a", {"b": ""})
+
+
+class TestPaginationArguments:
+    """The exact argument rendering of every paginated query."""
+
+    def test_consumption_query_with_first(self):
+        keys = list(QueryBuilder.consumption_query("HOURLY", first=2).keys())
+        assert keys == ["consumption(resolution: HOURLY, first: 2, filterEmptyNodes: false)"]
+
+    def test_consumption_query_with_last_before_and_filter(self):
+        keys = list(
+            QueryBuilder.consumption_query(
+                "DAILY", last=3, before="abc", filter_empty_nodes=True
+            ).keys()
+        )
+        assert keys == ['consumption(resolution: DAILY, last: 3, before: "abc", filterEmptyNodes: true)']
+
+    def test_production_query_with_first_and_after(self):
+        keys = list(QueryBuilder.production_query("HOURLY", first=1, after="xyz").keys())
+        assert keys == ['production(resolution: HOURLY, first: 1, after: "xyz", filterEmptyNodes: false)']
+
+    def test_range_query(self):
+        keys = list(QueryBuilder.range_query("DAILY", 2, None, None, "abc").keys())
+        assert keys == ['range(resolution: DAILY, first: 2, after: "abc")']
+
+    def test_price_info_range_query(self):
+        keys = list(
+            QueryBuilder.price_info_range_query("QUARTER_HOURLY", 10, None, None, "abc").keys()
+        )
+        assert keys == ['priceInfoRange(resolution: QUARTER_HOURLY, first: 10, after: "abc")']
+
+    def test_price_info_query(self):
+        keys = list(QueryBuilder.price_info_query("HOURLY").keys())
+        assert keys == ["priceInfo(resolution: HOURLY)"]
+
+    def test_paginated_queries_request_page_info_nodes_and_edges(self):
+        for query_dict in [
+            QueryBuilder.consumption_query("HOURLY", first=1),
+            QueryBuilder.production_query("HOURLY", first=1),
+            QueryBuilder.range_query("HOURLY", 1, None, None, None),
+            QueryBuilder.price_info_range_query("HOURLY", 1, None, None, None),
+        ]:
+            (fields,) = query_dict.values()
+            assert {"pageInfo", "nodes", "edges"} <= set(fields)
+
+
+def test_live_measurement_subscription_query():
+    query = QueryBuilder.live_measurement("home-id-123")
+    assert query.lstrip().startswith("subscription {")
+    assert 'liveMeasurement(homeId: "home-id-123")' in query
+    for field in ["timestamp", "power", "accumulatedCost", "currency", "signalStrength"]:
+        assert field in query
+
+
+def test_send_push_notification_without_screen_to_open():
+    query = QueryBuilder.send_push_notification("Title", "Message")
+    assert 'title: "Title",' in query
+    assert 'message: "Message",' in query
+    assert "screenToOpen" not in query
+
+
+def test_send_push_notification_with_screen_to_open():
+    query = QueryBuilder.send_push_notification("Title", "Message", "HOME")
+    assert "screenToOpen: HOME" in query

--- a/tests/unit/test_query_executor.py
+++ b/tests/unit/test_query_executor.py
@@ -1,0 +1,47 @@
+"""Offline tests for error handling and caching in the query executor / account."""
+import pytest
+
+from tibber.exceptions import APIException, UnauthenticatedException
+
+
+def test_unauthenticated_error_raises_unauthenticated_exception(unfetched_account):
+    error = {
+        "message": "invalid token",
+        "extensions": {"code": "UNAUTHENTICATED"},
+    }
+    with pytest.raises(UnauthenticatedException, match="invalid token"):
+        unfetched_account._process_error(error)
+
+
+def test_other_error_codes_raise_api_exception(unfetched_account):
+    error = {
+        "message": "something else went wrong",
+        "extensions": {"code": "INTERNAL_SERVER_ERROR"},
+    }
+    with pytest.raises(APIException):
+        unfetched_account._process_error(error)
+
+
+def test_malformed_error_raises_api_exception(unfetched_account):
+    with pytest.raises(APIException):
+        unfetched_account._process_error({"unexpected": "shape"})
+
+
+def test_setting_token_to_non_string_raises_type_error(unfetched_account):
+    with pytest.raises(TypeError):
+        unfetched_account.token = 42
+
+
+def test_setting_token_to_string_updates_token(unfetched_account):
+    unfetched_account.token = "new-token"
+    assert unfetched_account.token == "new-token"
+
+
+def test_update_cache_merges_new_data(unfetched_account):
+    unfetched_account.update_cache({"viewer": {"name": "Arya Stark"}})
+    unfetched_account.update_cache({"viewer": {"login": "arya@winterfell.com"}})
+    assert unfetched_account.cache == {
+        "viewer": {"name": "Arya Stark", "login": "arya@winterfell.com"}
+    }
+    assert unfetched_account.name == "Arya Stark"
+    assert unfetched_account.login == "arya@winterfell.com"

--- a/uv.lock
+++ b/uv.lock
@@ -1058,6 +1058,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1098,6 +1111,7 @@ dev = [
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytest-cov" },
+    { name = "pytest-timeout" },
     { name = "ruff" },
 ]
 
@@ -1115,6 +1129,7 @@ requires-dist = [
 dev = [
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
+    { name = "pytest-timeout", specifier = ">=2.3.1" },
     { name = "ruff", specifier = ">=0.15.6" },
 ]
 


### PR DESCRIPTION
Standalone PR (independent of the other phase PRs, no release increment). Closes #48.

## What changes

**The default suite no longer touches the network.** Previously every test run hit the live demo API and silently fell back to `backup_demo_data.json` on failure — so a run could test different things depending on network weather, and demo-account changes broke hardcoded assertions (your #48).

- The session `account` fixture now loads recorded demo data into the cache and stubs the connection step, so constructing it is instant and offline. I re-recorded `backup_demo_data.json` from the current demo account (it was stale: `size` 195 vs 200, `accountType`).
- Network tests are **opt-in via markers**: `live` (demo-API queries, i.e. `tests/fetched/`) and `realtime` (websocket tests). `--strict-markers` is on, and the default `addopts` deselects both.
- New **`live.yml`** workflow runs `-m "live or realtime"` weekly + on demand, so upstream API drift is still caught — just not by every PR.
- The offline-able "unknown event" test moved out of `tests/realtime/` into new offline event tests.

**New offline unit tests** for previously untested core logic (70 tests total now, runs in <1s):
- Golden tests locking the **exact GraphQL strings** `QueryBuilder` generates (incl. all pagination-argument rendering) — these protect the planned phase 5 internal cleanup.
- Error mapping: `UNAUTHENTICATED` → `UnauthenticatedException`, other/malformed errors → `APIException`.
- Cache merging (`update_cache`/`combine_dicts`) and event registration/broadcast behavior.

**Coverage** config moved from `.coveragerc` into `pyproject.toml` with `fail_under = 75` (offline suite measures 76%; the old `logger` exclude-line regex was dropped since it excluded every line containing "logger").

Verified locally: offline suite 70 passed / 5 deselected; `-m "live or realtime"` 5 passed against the real API.

Note: tiny overlap with #69 (both add `pytest-timeout` to the dev group — identical line, merges cleanly; needed here because `--strict-markers` would otherwise error on the `timeout` marker).

https://claude.ai/code/session_01JzYRijrUxTCV4REzcTPPEi

---
_Generated by [Claude Code](https://claude.ai/code/session_01JzYRijrUxTCV4REzcTPPEi)_