### PR TITLE
Fix CI matrix so each declared Python version is actually tested

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -35,8 +35,8 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install uv
         uses: astral-sh/setup-uv@v7
-      - name: Install Python
-        run: uv python install
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Restore uv cache
         uses: actions/cache@v5
         with:
@@ -98,8 +98,8 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install uv
         uses: astral-sh/setup-uv@v7
-      - name: Install Python 3.14
-        run: uv python install 3.14
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Restore uv cache
         uses: actions/cache@v5
         with:


### PR DESCRIPTION
One topic: make the CI Python matrix real.

The `Pytest` and `Build` jobs declare a 3.9 / 3.11 / 3.13 / 3.14 matrix, but every entry ran `uv python install`, which installs the `.python-version` pin (3.14). So all eight matrix jobs were actually testing Python 3.14, and 3.9 compatibility was never exercised in CI.

The fix is to pass the matrix version to `setup-uv` (`python-version:` sets `UV_PYTHON`), which makes `uv sync`, `pytest` and the wheel/sdist smoke tests run on the declared interpreter. The `Coverage` job has no matrix and is untouched.

Verified locally that the suite passes on a real Python 3.9 (`uv run --python 3.9 ... pytest tests` → 46 passed), so the matrix should go green.

Two-line diff, independent of the other open PRs (different hunks of the same workflow file as #69 — they merge cleanly in either order).

https://claude.ai/code/session_01JzYRijrUxTCV4REzcTPPEi

---
_Generated by [Claude Code](https://claude.ai/code/session_01JzYRijrUxTCV4REzcTPPEi)_