### PR TITLE
docs: update docs to v0.7.1 and verify all code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ python -m pip install tibber.py
 
 ### Requirements
 
-tibber.py depends on `gql`, `gql[aiohttp]`, `gql[websockets]` and `graphql-core`. tibber.py supports Python versions 3.9 and up!
+tibber.py depends on `gql`, `gql[aiohttp]`, `gql[websockets]`, `graphql-core`, `backoff` and `asyncio-atexit`. tibber.py supports Python versions 3.9 and up!
 
 ## Examples
 
@@ -69,7 +69,7 @@ home = account.homes[0]
 print(home.id)                     # "96a14971-525a-4420-aae9-e5aedaa129ff"
 print(home.time_zone)              # "Europe/Stockholm"
 print(home.app_nickname)           # "Vitahuset"
-print(home.app_avatar)             # "FLOORHOUSE2"
+print(home.app_avatar)             # "CASTLE"
 print(home.size)                   # 200
 print(home.type)                   # "HOUSE"
 print(home.number_of_residents)    # 5
@@ -127,7 +127,7 @@ connection.nodes  # A list of Price objects
 ### Reading live measurements
 
 Note how you can register multiple callbacks for the same event. These will be run
-in asynchronously (at the same time)!
+asynchronously (at the same time)!
 
 ```python
 import tibber

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = "2025, Eric Bieszczad-Stie"
 author = "Eric Bieszczad-Stie"
 
 # The full version, including alpha/beta/rc tags
-release = "0.5.0"
+release = "0.7.1"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -38,9 +38,9 @@ in the form of a list. Let's get the first home in the list!
 
 .. code-block:: python
 
-   print(account.homes)  # [<Home: Home 1>, <Home: Home 2>, ...]
+   print(account.homes)  # [<tibber.types.home.TibberHome object at 0x...>]
    home = account.homes[0]
-   print(home)  # <Home: Home 1>
+   print(home.app_nickname)  # "Vitahuset"
 
 
 #############################################
@@ -55,10 +55,10 @@ Since we're fetching data from the API and not just getting it from the cache, w
 .. code-block:: python
 
    consumption = home.fetch_consumption(resolution = "HOURLY", last = 24)  # last 24 hours
-   print(consumption)  # <HomeConsumptionConnection: HomeConsumptionConnection>
+   print(consumption)  # <tibber.types.home_consumption_connection.HomeConsumptionConnection object at 0x...>
 
 Back in the API explorer documentation, clicking the yellow underlined text "HomeConsumptionConnection" we see that it has a
-"nodes" attribute wich has a list of consumptions. Within the Consumption type you have all the goodies such as cost,
+"nodes" attribute which has a list of consumptions. Within the Consumption type you have all the goodies such as cost,
 unit price, currency etc. Let's print the cost of the last 24 hours!
 
 .. code-block:: python
@@ -90,6 +90,54 @@ account as the one you have generated your access token with.
 
    account = tibber.Account("your token")
    account.send_push_notification("My title", "Hello! I'm a message!")
+
+.. note::
+   Push notifications cannot be sent with the demo token. The API will
+   respond with "operation not allowed for demo user". Use an access
+   token generated for your own account instead.
+
+#########################
+Getting price information
+#########################
+
+The current subscription of a home holds price information. You can fetch
+today's (and, after they are published, tomorrow's) prices with the
+``fetch_price_info()`` method. It takes the resolution as an argument,
+which can be either ``QUARTER_HOURLY`` or ``HOURLY``.
+
+.. code-block:: python
+
+   import tibber
+
+   account = tibber.Account("your token")
+   subscription = account.homes[0].current_subscription
+
+   price_info = subscription.fetch_price_info("QUARTER_HOURLY")
+
+   print(price_info.today)     # A list of 96 Price objects
+   print(price_info.tomorrow)  # This data is populated once a day
+
+To get historical prices, use the ``fetch_price_info_range()`` method. It
+supports the ``QUARTER_HOURLY``, ``HOURLY`` and ``DAILY`` resolutions. The
+API requires the date to be passed as a base64 encoded ISO 8601 datetime
+with timezone information.
+
+.. code-block:: python
+
+   import tibber
+   import datetime
+   import base64
+
+   account = tibber.Account("your token")
+   subscription = account.homes[0].current_subscription
+
+   date = datetime.datetime(2025, 1, 1, 0, 0, 0)
+   encoded_date = base64.b64encode(date.astimezone().isoformat().encode("utf-8")).decode("utf-8")
+
+   connection = subscription.fetch_price_info_range("HOURLY", first=10, after=encoded_date)
+
+   for price in connection.nodes:
+      print(price.starts_at, price.total, price.currency)
 
 #################
 Live measurements
@@ -143,24 +191,27 @@ will be stopped (and code execution will continue).
       print(data.power)
 
    # Now start retrieving live measurements
-   home.start_live_feed(user_agent="program/1.0", exit_condition = lambda: True)  # This will stop the live feed after the first measurement
+   home.start_live_feed(user_agent="program/1.0", exit_condition = lambda data: True)  # This will stop the live feed after the first measurement
+
+The exit condition function receives the latest LiveMeasurement as its only
+argument, so you can stop the live feed based on the data it contains.
 
 .. code-block:: python
-   
-      import tibber
-   
-      account = tibber.Account("your token")
-      home = account.homes[0]
-   
-      @home.event("live_measurement")  # register the following function to run when the live_measurement event is emitted
-      async def process_data(data):  # Note the data parameter in the function. This is required and is of type LiveMeasurement.
-         print(data.power)
 
-      def my_exit_function(live_measurement_data):
-         return live_measurement_data.power > 1000:
-   
-      # Now start retrieving live measurements
-      home.start_live_feed(user_agent="program/1.0", exit_condition = my_exit_function)  # This will stop the live feed when the power is above 1000
-      print("We made it! The power is above 1000!")
+   import tibber
 
-For more examples, check out the `README <https://github.com/BeatsuDev/tibber.py>`_ of the project on GitHub.
+   account = tibber.Account("your token")
+   home = account.homes[0]
+
+   @home.event("live_measurement")  # register the following function to run when the live_measurement event is emitted
+   async def process_data(data):  # Note the data parameter in the function. This is required and is of type LiveMeasurement.
+      print(data.power)
+
+   def my_exit_function(live_measurement_data):
+      return live_measurement_data.power > 1000
+
+   # Now start retrieving live measurements
+   home.start_live_feed(user_agent="program/1.0", exit_condition = my_exit_function)  # This will stop the live feed when the power is above 1000
+   print("We made it! The power is above 1000!")
+
+For more examples, check out the `README <https://github.com/ericbstie/tibber.py>`_ of the project on GitHub.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,11 +26,11 @@ Welcome to tibber.py's documentation!
    close correlation to the Tibber API is explained further in the Introduction
    section).
 
-`tibber.py <https://github.com/BeatsuDev/tibber.py>`_ is an unofficial 
+`tibber.py <https://github.com/ericbstie/tibber.py>`_ is an unofficial
 `wrapper library <https://en.wikipedia.org/wiki/Wrapper_library>`_ for the
-`Tibber API <https://developer.tibber.com/>`_ developed and maintained by BeatsuDev.
-To quickly get started with common operations with the tibber.py library, 
-you can head over to the `GitHub repo <https://github.com/BeatsuDev/tibber.py>`_
+`Tibber API <https://developer.tibber.com/>`_.
+To quickly get started with common operations with the tibber.py library,
+you can head over to the `GitHub repo <https://github.com/ericbstie/tibber.py>`_
 and read the README.md file. There you can also see the source code of the library.
 
 ############
@@ -69,7 +69,7 @@ it's properties and methods.
 ####################################
 How to contribute or report an issue
 ####################################
-To report an issue or bug, go to the `GitHub repository <https://github.com/BeatsuDev/tibber.py>`_
+To report an issue or bug, go to the `GitHub repository <https://github.com/ericbstie/tibber.py>`_
 and create a new issue describing your problem and how to reproduce it. Also
 include what the *expected* behaviour was, and what the actual behaviour was.
 

--- a/src/tibber/networking/query_executor.py
+++ b/src/tibber/networking/query_executor.py
@@ -72,10 +72,10 @@ class QueryExecutor:
         """
         backoff_execution = backoff.on_exception(
             backoff.expo,
-            [
+            (
                 gql.transport.exceptions.TransportClosed,
                 websockets.exceptions.ConnectionClosedError,
-            ],
+            ),
             max_tries=max_tries,
             max_time=100,
             jitter=backoff.full_jitter,

--- a/src/tibber/types/home.py
+++ b/src/tibber/types/home.py
@@ -325,10 +325,10 @@ class TibberHome(NonDecoratedTibberHome):
 
         retry_connect = backoff.on_exception(
             backoff.expo,
-            [
+            (
                 gql.transport.exceptions.TransportClosed,
                 websockets.exceptions.ConnectionClosedError,
-            ],
+            ),
             max_value=100,
             max_tries=retries,
             on_backoff=lambda details: _logger.warning(

--- a/tests/cached/test_account.py
+++ b/tests/cached/test_account.py
@@ -47,7 +47,7 @@ def test_homes_are_correct_type(account):
 
 def test_getting_non_fetched_property_returns_none_or_empty(unfetched_account):
     """Trying to get a value which has not yet been fetched should return None"""
-    assert unfetched_account.name == None
+    assert unfetched_account.name is None
     assert unfetched_account.viewer.homes == []
 
 

--- a/tests/cached/test_home.py
+++ b/tests/cached/test_home.py
@@ -38,7 +38,7 @@ def test_getting_primary_heating_source(home):
 
 
 def test_getting_has_ventilation_system(home):
-    assert home.has_ventilation_system == False
+    assert not home.has_ventilation_system
 
 
 def test_getting_main_fuse_size(home):


### PR DESCRIPTION
- Bump Sphinx release from 0.5.0 to 0.7.1
- Point remaining BeatsuDev links at this repository
- Fix exit_condition examples: the callback receives a LiveMeasurement,
  so the bare lambda raised a TypeError; also remove a stray colon and
  broken indentation in the third live feed example
- Document fetch_price_info() and fetch_price_info_range() added in 0.7.x
- Note that push notifications are rejected for the demo user
- Correct printed repr/output comments and the demo app_avatar value
- List backoff and asyncio-atexit in the README requirements

Every code example in README.md and docs/ was executed against the
live Tibber API with the demo token.

https://claude.ai/code/session_01EXBKgK9r1GZiQti2NH5XN4