### PR TITLE
Migrate price range queries off deprecated PriceInfo.range field

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,14 +112,14 @@ import base64
 
 
 account = tibber.Account(tibber.DEMO_TOKEN)
-price_info = account.homes[0].current_subscription.price_info
+subscription = account.homes[0].current_subscription
 
 # The API requires the date to be passed as a base64 encoded string with timezone information
 date = datetime.datetime(2025, 1, 1, 0, 0, 0)
 encoded_date = base64.b64encode(date.astimezone().isoformat().encode("utf-8")).decode("utf-8")
 
-# Only HOURLY and DAILY
-connection = price_info.fetch_range("HOURLY", first=10, after=encoded_date)
+# QUARTER_HOURLY, HOURLY or DAILY
+connection = subscription.fetch_price_info_range("HOURLY", first=10, after=encoded_date)
 
 connection.nodes  # A list of Price objects
 ```

--- a/src/tibber/networking/query_builder.py
+++ b/src/tibber/networking/query_builder.py
@@ -320,30 +320,6 @@ class QueryBuilder:
         }
 
     @classmethod
-    def range_query(
-        cls, resolution: str, first: int, last: int, before: str, after: str
-    ):
-        first_arg = f"first: {first}" if first else None
-        last_arg = f"last: {last}" if last else None
-        before_arg = f'before: "{before}"' if before else None
-        after_arg = f'after: "{after}"' if after else None
-
-        args = ", ".join(
-            [
-                arg
-                for arg in [first_arg, last_arg, before_arg, after_arg]
-                if arg is not None
-            ]
-        )
-        return {
-            f"range(resolution: {resolution}, {args})": {
-                "pageInfo": QueryBuilder.subscription_price_connection_page_info(),
-                "edges": QueryBuilder.subscription_price_edge(),
-                "nodes": QueryBuilder.price(),
-            }
-        }
-
-    @classmethod
     def consumption_query(
         cls,
         resolution: str,

--- a/src/tibber/types/price_info.py
+++ b/src/tibber/types/price_info.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 """A class representing the PriceInfo type from the GraphQL Tibber API."""
+import warnings
 from typing import TYPE_CHECKING, Optional
 
 from tibber.networking.query_builder import QueryBuilder
@@ -50,16 +51,30 @@ class PriceInfo:
     ) -> SubscriptionPriceConnection:
         """Fetch the price range.
 
+        .. deprecated::
+            The underlying `PriceInfo.range` field is deprecated by the Tibber API
+            (moved to `Subscription.priceInfoRange` with the introduction of
+            quarter hourly prices on October 1st, 2025). Use
+            `Subscription.fetch_price_info_range` instead.
+
         The before and after arguments are Base64 encoded ISO 8601 datetimes."""
-        range_query_dict = QueryBuilder.range_query(
+        warnings.warn(
+            "PriceInfo.fetch_range is deprecated because the Tibber API deprecated "
+            "the underlying PriceInfo.range field. "
+            "Use Subscription.fetch_price_info_range instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        price_info_range_query_dict = QueryBuilder.price_info_range_query(
             resolution, first, last, before, after
         )
 
-        range_query = QueryBuilder.create_query(
-            "viewer", "homes", "currentSubscription", "priceInfo", range_query_dict
+        price_info_range_query = QueryBuilder.create_query(
+            "viewer", "homes", "currentSubscription", price_info_range_query_dict
         )
         full_data = self.tibber_client.execute_query(
-            self.tibber_client.token, range_query
+            self.tibber_client.token, price_info_range_query
         )
 
         home = full_data["viewer"]["homes"][0]
@@ -72,5 +87,5 @@ class PriceInfo:
                 home = home_of_id
 
         return SubscriptionPriceConnection(
-            home["currentSubscription"]["priceInfo"]["range"], self.tibber_client
+            home["currentSubscription"]["priceInfoRange"], self.tibber_client
         )

--- a/tests/cached/test_account.py
+++ b/tests/cached/test_account.py
@@ -47,7 +47,7 @@ def test_homes_are_correct_type(account):
 
 def test_getting_non_fetched_property_returns_none_or_empty(unfetched_account):
     """Trying to get a value which has not yet been fetched should return None"""
-    assert unfetched_account.name == None
+    assert unfetched_account.name is None
     assert unfetched_account.viewer.homes == []
 
 

--- a/tests/cached/test_home.py
+++ b/tests/cached/test_home.py
@@ -38,7 +38,7 @@ def test_getting_primary_heating_source(home):
 
 
 def test_getting_has_ventilation_system(home):
-    assert home.has_ventilation_system == False
+    assert not home.has_ventilation_system
 
 
 def test_getting_main_fuse_size(home):

--- a/tests/fetched/test_range.py
+++ b/tests/fetched/test_range.py
@@ -3,16 +3,53 @@
 import base64
 from datetime import datetime, timedelta, timezone
 
+import pytest
 
-def test_fetching_hourly_prices(home):
-    date = datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone(timedelta(hours=1)))
-    encoded = base64.b64encode(date.astimezone().isoformat().encode("utf-8")).decode(
+
+def encode_date(date: datetime) -> str:
+    return base64.b64encode(date.astimezone().isoformat().encode("utf-8")).decode(
         "utf-8"
     )
 
-    data = home.current_subscription.price_info.fetch_range(
-        "HOURLY", first="3", after=encoded
+
+def test_fetching_hourly_prices(home):
+    date = datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone(timedelta(hours=1)))
+
+    data = home.current_subscription.fetch_price_info_range(
+        "HOURLY", first="3", after=encode_date(date)
     )
+
+    assert data.page_info.count == 3
+    assert len(data.nodes) == 3
+
+    assert data.nodes[0].starts_at == "2025-01-01T00:00:00.000+01:00"
+    assert data.nodes[1].starts_at == "2025-01-01T01:00:00.000+01:00"
+    assert data.nodes[2].starts_at == "2025-01-01T02:00:00.000+01:00"
+
+
+def test_fetching_quarter_hourly_prices(home):
+    date = datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone(timedelta(hours=1)))
+
+    data = home.current_subscription.fetch_price_info_range(
+        "QUARTER_HOURLY", first="4", after=encode_date(date)
+    )
+
+    assert data.page_info.count == 4
+    assert len(data.nodes) == 4
+
+    assert data.nodes[0].starts_at == "2025-01-01T00:00:00.000+01:00"
+    assert data.nodes[1].starts_at == "2025-01-01T00:15:00.000+01:00"
+    assert data.nodes[2].starts_at == "2025-01-01T00:30:00.000+01:00"
+    assert data.nodes[3].starts_at == "2025-01-01T00:45:00.000+01:00"
+
+
+def test_deprecated_fetch_range_warns_and_delegates(home):
+    date = datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone(timedelta(hours=1)))
+
+    with pytest.warns(DeprecationWarning, match="fetch_price_info_range"):
+        data = home.current_subscription.price_info.fetch_range(
+            "HOURLY", first="3", after=encode_date(date)
+        )
 
     assert data.page_info.count == 3
     assert len(data.nodes) == 3


### PR DESCRIPTION
Tibber deprecated PriceInfo.range and moved it to Subscription.priceInfoRange
with the introduction of quarter-hourly prices on October 1st, 2025. The old
field still works but does not support QUARTER_HOURLY resolution and may be
removed.

- PriceInfo.fetch_range now queries priceInfoRange and emits a
  DeprecationWarning pointing users to Subscription.fetch_price_info_range
- Remove QueryBuilder.range_query, which built the deprecated query and had
  no other callers
- Replace the deprecated example in the README with
  Subscription.fetch_price_info_range
- Add test coverage for fetch_price_info_range and assert the deprecation
  warning on the old path
- Bump version to 0.8.0

https://claude.ai/code/session_01JLW7BaJzkXbmPqqVYqZ1Xe