### PR TITLE
Make the sync API a thin facade over a dedicated event loop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
     "gql[websockets]>=3.4.0",
     "graphql-core>=3.2.3",
     "backoff>=2.2.1",
-    "asyncio-atexit>=1.0.1",
 ]
 classifiers = [
     "Development Status :: 1 - Planning",

--- a/src/tibber/networking/query_executor.py
+++ b/src/tibber/networking/query_executor.py
@@ -50,6 +50,12 @@ class QueryExecutor:
 
     def _run_coroutine_threadsafe(self, coroutine):
         """Runs a coroutine on the executor's event loop and waits for the result."""
+        if threading.current_thread() is self._loop_thread:
+            # Blocking on the executor loop from its own thread would deadlock.
+            raise RuntimeError(
+                "The sync API cannot be used from the executor's event loop."
+                " Use the async API (e.g. execute_async or update_async) instead."
+            )
         return asyncio.run_coroutine_threadsafe(coroutine, self._loop).result()
 
     def _shutdown(self):

--- a/src/tibber/networking/query_executor.py
+++ b/src/tibber/networking/query_executor.py
@@ -1,7 +1,8 @@
 import asyncio
+import atexit
 import logging
+import threading
 
-import asyncio_atexit
 import backoff
 import gql
 import websockets
@@ -15,7 +16,13 @@ _logger = logging.getLogger(__name__)
 
 
 class QueryExecutor:
-    """A class for executing queries."""
+    """A class for executing queries.
+
+    The async core runs on a dedicated event loop in a background thread.
+    The sync methods are a thin facade that submit work to that loop, so
+    they are safe to call from any context - including inside a running
+    event loop.
+    """
 
     def __init__(self, session=None, transport_kwargs={}):
         self.gql_client = None
@@ -29,11 +36,31 @@ class QueryExecutor:
             transport=transport, fetch_schema_from_transport=True
         )
 
-        asyncio.run(self.__ainit__(session))
+        self._loop = asyncio.new_event_loop()
+        self._loop_thread = threading.Thread(
+            target=self._loop.run_forever, name="tibber-query-executor", daemon=True
+        )
+        self._loop_thread.start()
+        atexit.register(self._shutdown)
+
+        self._run_coroutine_threadsafe(self.__ainit__(session))
 
     async def __ainit__(self, session):
         self.session = session or await self.gql_client.connect_async()
-        asyncio_atexit.register(self.gql_client.close_async)
+
+    def _run_coroutine_threadsafe(self, coroutine):
+        """Runs a coroutine on the executor's event loop and waits for the result."""
+        return asyncio.run_coroutine_threadsafe(coroutine, self._loop).result()
+
+    def _shutdown(self):
+        if self._loop.is_closed():
+            return
+        try:
+            self._run_coroutine_threadsafe(self.gql_client.close_async())
+        finally:
+            self._loop.call_soon_threadsafe(self._loop.stop)
+            self._loop_thread.join(timeout=5)
+            self._loop.close()
 
     def execute_query(
         self, access_token: str, query: str, max_tries: int = 1, **kwargs
@@ -45,20 +72,9 @@ class QueryExecutor:
         :param max_tries: The amount of attempts before giving up. Set to None for infinite tries.
         :param **kwargs: Arguments to be passed in to the backoff.on_exception decorator
         """
-        # To allow invocations from async contexts, check if a loop is running and attempt
-        # to schedule the execute_async method there. If no loop is found or the loop is not
-        # running, asyncio.run can be run instead.
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            loop = None
-
-        if loop and loop.is_running():
-            return loop.run_until_complete(
-                self.execute_async(access_token, query, max_tries, **kwargs)
-            )
-
-        return asyncio.run(self.execute_async(access_token, query, max_tries, **kwargs))
+        return self._run_coroutine_threadsafe(
+            self._execute_with_backoff(access_token, query, max_tries, **kwargs)
+        )
 
     async def execute_async(
         self, access_token: str, query: str, max_tries: int = 1, **kwargs
@@ -70,6 +86,15 @@ class QueryExecutor:
         :param max_tries: The amount of attempts before giving up. Set to None for infinite tries.
         :param **kwargs: Arguments to be passed in to the backoff.on_exception decorator
         """
+        future = asyncio.run_coroutine_threadsafe(
+            self._execute_with_backoff(access_token, query, max_tries, **kwargs),
+            self._loop,
+        )
+        return await asyncio.wrap_future(future)
+
+    async def _execute_with_backoff(
+        self, access_token: str, query: str, max_tries: int = 1, **kwargs
+    ):
         backoff_execution = backoff.on_exception(
             backoff.expo,
             (
@@ -90,7 +115,7 @@ class QueryExecutor:
 
     async def execute_async_single(self, access_token: str, query: str):
         try:
-            result = await self.gql_client.execute_async(gql.gql(query))
+            result = await self.session.execute(gql.gql(query))
         except TransportQueryError as e:
             for error in e.errors:
                 self._process_error(error)

--- a/tests/fetched/test_sync_facade.py
+++ b/tests/fetched/test_sync_facade.py
@@ -1,0 +1,38 @@
+"""Tests that the sync API is a thin facade over the async core and works
+from any calling context, including inside a running event loop (issue #65)."""
+import asyncio
+
+import tibber
+
+
+def test_account_can_be_created_inside_a_running_event_loop():
+    async def main():
+        return tibber.Account(tibber.DEMO_TOKEN)
+
+    account = asyncio.run(main())
+    assert account.name == "Arya Stark"
+
+
+def test_sync_fetch_works_inside_a_running_event_loop(home):
+    async def main():
+        return home.fetch_consumption("HOURLY", first=2)
+
+    data = asyncio.run(main())
+    assert len(data.nodes) == 2
+
+
+def test_sync_fetch_price_info_works_inside_a_running_event_loop(home):
+    """The exact scenario reported in issue #65."""
+    async def main():
+        return home.current_subscription.fetch_price_info("HOURLY")
+
+    price_info = asyncio.run(main())
+    assert len(price_info.today) > 0
+
+
+def test_update_async_still_works_from_a_user_event_loop(account):
+    async def main():
+        await account.update_async()
+
+    asyncio.run(main())
+    assert account.name == "Arya Stark"

--- a/tests/fetched/test_sync_facade.py
+++ b/tests/fetched/test_sync_facade.py
@@ -1,5 +1,6 @@
 """Tests that the sync API is a thin facade over the async core and works
 from any calling context, including inside a running event loop (issue #65)."""
+
 import asyncio
 
 import tibber
@@ -23,6 +24,7 @@ def test_sync_fetch_works_inside_a_running_event_loop(home):
 
 def test_sync_fetch_price_info_works_inside_a_running_event_loop(home):
     """The exact scenario reported in issue #65."""
+
     async def main():
         return home.current_subscription.fetch_price_info("HOURLY")
 

--- a/uv.lock
+++ b/uv.lock
@@ -191,15 +191,6 @@ wheels = [
 ]
 
 [[package]]
-name = "asyncio-atexit"
-version = "1.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/22/d3/dd2974be3f67c7ec96e0d6ab454429d0372cb7c7bffa3d0ac67a483cb801/asyncio-atexit-1.0.1.tar.gz", hash = "sha256:1d0c71544b8ee2c484d322844ee72c0875dde6f250c0ed5b6993592ab9f7d436", size = 4373, upload-time = "2022-04-26T08:54:16.998Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/10/d6abaefa57a52646651fd0383c056280b0853c0106229ece6bb38cd14463/asyncio_atexit-1.0.1-py3-none-any.whl", hash = "sha256:d93d5f7d5633a534abd521ce2896ed0fbe8de170bb1e65ec871d1c20eac9d376", size = 3752, upload-time = "2022-04-26T08:54:15.726Z" },
-]
-
-[[package]]
 name = "attrs"
 version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1087,7 +1078,6 @@ name = "tibber-py"
 version = "0.7.1"
 source = { editable = "." }
 dependencies = [
-    { name = "asyncio-atexit" },
     { name = "backoff" },
     { name = "gql", extra = ["aiohttp", "websockets"] },
     { name = "graphql-core" },
@@ -1103,7 +1093,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "asyncio-atexit", specifier = ">=1.0.1" },
     { name = "backoff", specifier = ">=2.2.1" },
     { name = "gql", specifier = "==3.5.3" },
     { name = "gql", extras = ["aiohttp"], specifier = ">=3.4.0" },


### PR DESCRIPTION
One topic: the sync API must work from any calling context. Fixes #65.

Built test-first; the three commits are the red-green-refactor steps and are meant to be read in order:

1. **Red** — `tests/fetched/test_sync_facade.py` pins the desired behavior: constructing `Account` and calling `fetch_*` inside a running event loop (the exact #65 scenario), plus a regression guard that `update_async` stays awaitable from a user loop. Three of four fail on master with `RuntimeError: This event loop is already running`.
2. **Green** — `QueryExecutor` now owns a background event-loop thread. `execute_query` (and everything built on it) submits the coroutine there and blocks on the result; `execute_async` submits to the same loop and awaits a wrapped future. No public API change.
3. **Refactor** — drop the now-unused `asyncio-atexit` dependency (one dependency fewer) and fail fast with a clear message if the sync facade is ever invoked from the executor loop's own thread, where blocking would deadlock.

Two behavior notes worth knowing:
- Queries now reuse **one persistent connection** (`session.execute`). Previously every query reconnected from scratch, which only worked because `asyncio-atexit` happened to tear the session down each time an `asyncio.run()` loop closed.
- Cleanup is an explicit `atexit` hook that closes the gql client and stops the loop.

Out of scope, same disease: `start_live_feed` has its own `run_until_complete`-on-a-running-loop branch (`home.py:280`). The websocket code manages a separate client/loop, so it deserves its own PR on top of this one.

Verified: full suite 50 passed (46 existing + 4 new) against the live demo API; `ruff check` and `ruff format --check` clean. Note the red commit fails CI by design — the branch head is green.

https://claude.ai/code/session_01Hbttq2MCvyEBNgUk6Vzc2z

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hbttq2MCvyEBNgUk6Vzc2z)_